### PR TITLE
chore: Improve explanations in ok pkg install --help

### DIFF
--- a/cmd/pkg/install.go
+++ b/cmd/pkg/install.go
@@ -7,7 +7,7 @@ import (
 
 var InstallCommand = &cobra.Command{
 	Use:   "install [outputFolder ...]",
-	Short: "Install or update Boilerplate packages",
+	Short: "Install or update Boilerplate packages.",
 	Long: `Install or update Boilerplate packages.
 
 If no arguments are used, the command installs all the packages specified in the package manifest file.

--- a/cmd/pkg/install.go
+++ b/cmd/pkg/install.go
@@ -12,8 +12,7 @@ var InstallCommand = &cobra.Command{
 
 If no arguments are used, the command installs all the packages specified in the package manifest file.
 
-If one or more output folders are specified, the command installs only the packages from the package manifest that has
-OutputFolder that matches one of the specified output folders.
+If one or more output folders are specified, the command installs only the packages whose OutputFolder matches the specified folders. (OutputFolder is a field in the package manifest file.)
 `,
 	Examples: `ok install networking
 ok install networking my-app

--- a/cmd/pkg/install.go
+++ b/cmd/pkg/install.go
@@ -6,8 +6,18 @@ import (
 )
 
 var InstallCommand = &cobra.Command{
-	Use:           "install [stackName1, stackName2, ...]",
-	Short:         "Install or update Boilerplate packages",
+	Use:   "install [outputFolder ...]",
+	Short: "Install or update Boilerplate packages",
+	Long: `Install or update Boilerplate packages.
+
+If no arguments are used, the command installs all the packages specified in the package manifest file.
+
+If one or more output folders are specified, the command installs only the packages from the package manifest that has
+OutputFolder that matches one of the specified output folders.
+`,
+	Example: `ok install networking
+ok install networking my-app
+`,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := install.Run(args)

--- a/cmd/pkg/install.go
+++ b/cmd/pkg/install.go
@@ -15,7 +15,7 @@ If no arguments are used, the command installs all the packages specified in the
 If one or more output folders are specified, the command installs only the packages from the package manifest that has
 OutputFolder that matches one of the specified output folders.
 `,
-	Example: `ok install networking
+	Examples: `ok install networking
 ok install networking my-app
 `,
 	SilenceErrors: true,


### PR DESCRIPTION
# Motivation

Be more precise and clear about what actually happens when running e.g.g `ok pkg install someFolder`.
