### PR TITLE
feat: Use version from Goreleaser

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -14,8 +14,8 @@ var getCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		baseURL := "git@github.com:oslokommune/golden-path-boilerplate.git//boilerplate"
 		ref := "main"
-		if okGetVersion != "" {
-			ref = okGetVersion
+		if version != "" {
+			ref = version
 		}
 		if outputFolder == "" {
 			outputFolder = templateName
@@ -46,12 +46,12 @@ var getCommand = &cobra.Command{
 
 var templateName string
 var outputFolder string
-var okGetVersion string
+var version string
 
 func init() {
 	getCommand.Flags().StringVarP(&templateName, "template", "t", "", "Template name (required)")
 	getCommand.MarkFlagRequired("template")
 	getCommand.Flags().StringVarP(&outputFolder, "output-folder", "o", "", "Output folder (optional)")
-	getCommand.Flags().StringVarP(&okGetVersion, "version", "v", "", "Version (optional)")
+	getCommand.Flags().StringVarP(&version, "version", "v", "", "Version (optional)")
 	rootCmd.AddCommand(getCommand)
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -14,8 +14,8 @@ var getCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		baseURL := "git@github.com:oslokommune/golden-path-boilerplate.git//boilerplate"
 		ref := "main"
-		if version != "" {
-			ref = version
+		if okGetVersion != "" {
+			ref = okGetVersion
 		}
 		if outputFolder == "" {
 			outputFolder = templateName
@@ -46,12 +46,12 @@ var getCommand = &cobra.Command{
 
 var templateName string
 var outputFolder string
-var version string
+var okGetVersion string
 
 func init() {
 	getCommand.Flags().StringVarP(&templateName, "template", "t", "", "Template name (required)")
 	getCommand.MarkFlagRequired("template")
 	getCommand.Flags().StringVarP(&outputFolder, "output-folder", "o", "", "Output folder (optional)")
-	getCommand.Flags().StringVarP(&version, "version", "v", "", "Version (optional)")
+	getCommand.Flags().StringVarP(&okGetVersion, "version", "v", "", "Version (optional)")
 	rootCmd.AddCommand(getCommand)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
-	"github.com/oslokommune/ok/internal/scriptrunner"
+	_ "embed"
+	"fmt"
 	"github.com/spf13/cobra"
 )
+
+var VersionData Version
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
@@ -13,7 +16,14 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version of the ok tool and the current latest version available.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fullArgs := append([]string{"version"}, args...)
-		scriptrunner.RunScript("ok.sh", fullArgs)
+		fmt.Printf("Version: %s\n", VersionData.Version)
+		fmt.Printf("Date:    %s\n", VersionData.Date)
+		fmt.Printf("Commit:  %s\n", VersionData.Commit)
 	},
+}
+
+type Version struct {
+	Version string
+	Date    string
+	Commit  string
 }

--- a/main.go
+++ b/main.go
@@ -7,8 +7,21 @@ import (
 	"os"
 )
 
+var (
+	version = "dev"
+	date    = "unknown"
+	commit  = "none"
+)
+
 func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
 
+	cmd.VersionData = cmd.Version{
+		Version: version,
+		Date:    date,
+		Commit:  commit,
+	}
+
 	cmd.Execute()
+
 }


### PR DESCRIPTION
# Description

See [GoReleaser ldlflags](https://goreleaser.com/cookbooks/using-main.version/).

> By default, GoReleaser will set the following 3 ldflags:
main.version: Current Git tag (the v prefix is stripped) or the name of the snapshot, if you're using the --snapshot flag
main.commit: Current git commit SHA
main.date: Date in the [RFC3339](https://pkg.go.dev/time#pkg-constants) format

This in turn sets`version`, `commit` and `date` variables:

https://github.com/oslokommune/ok/blob/af8801f19792b30adaee754926f4ec591a87cb53/main.go#L11

This can be tested locally:

```sh
go build -ldflags "-X main.version=1.0.0 -X main.commit=abc1234 -X main.date=$(date +%Y-%m-%dT%H:%M:%SZ)" -o ok .

./ok version

Version: 1.0.0
Date:    2024-07-17T12:07:21Z
Commit:  abc1234
```

# Motivation

`ok version` should match the actual released version from Goreleaser.