### PR TITLE
feat: Add DefaultTemplatePathPrefix

### DIFF
--- a/pkg/pkg/common/manifest.go
+++ b/pkg/pkg/common/manifest.go
@@ -3,8 +3,8 @@ package common
 import "fmt"
 
 type PackageManifest struct {
-	Packages                  []Package `yaml:"Packages"`
-	DefaultTemplatePathPrefix string    `yaml:"DefaultTemplatePathPrefix"`
+	Packages                 []Package `yaml:"Packages"`
+	DefaultPackagePathPrefix string    `yaml:"DefaultPackagePathPrefix"`
 }
 
 type Package struct {

--- a/pkg/pkg/common/manifest.go
+++ b/pkg/pkg/common/manifest.go
@@ -3,7 +3,8 @@ package common
 import "fmt"
 
 type PackageManifest struct {
-	Packages []Package `yaml:"Packages"`
+	Packages                  []Package `yaml:"Packages"`
+	DefaultTemplatePathPrefix string    `yaml:"DefaultTemplatePathPrefix"`
 }
 
 type Package struct {

--- a/pkg/pkg/install/install.go
+++ b/pkg/pkg/install/install.go
@@ -10,7 +10,7 @@ import (
 )
 
 const DefaultBaseUrl = "git@github.com:oslokommune/golden-path-boilerplate.git//"
-const DefaultTemplatePathPrefix = "boilerplate/terraform"
+const DefaultPackagePathPrefix = "boilerplate/terraform"
 
 func Run(pkgManifestFilename string, outputFolders []string) error {
 	cmds, err := CreateBoilerplateCommands(pkgManifestFilename, outputFolders)
@@ -76,7 +76,7 @@ func CreateBoilerplateCommands(pkgManifestFilename string, outputFolders []strin
 	}
 
 	// Install packages
-	cmds, err := createBoilerPlateCommands(packagesToInstall, manifest.DefaultTemplatePathPrefix)
+	cmds, err := createBoilerPlateCommands(packagesToInstall, manifest.DefaultPackagePathPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("creating boilerplate commands: %w", err)
 	}
@@ -101,7 +101,7 @@ func filterPackages(packages []common.Package, outputFolders []string) []common.
 	return result
 }
 
-func createBoilerPlateCommands(packagesToInstall []common.Package, templatePathPrefix string) ([]*exec.Cmd, error) {
+func createBoilerPlateCommands(packagesToInstall []common.Package, packagePathPrefix string) ([]*exec.Cmd, error) {
 	var cmds []*exec.Cmd
 	for _, pkg := range packagesToInstall {
 		var envBaseUrl = os.Getenv("BASE_URL")
@@ -109,12 +109,12 @@ func createBoilerPlateCommands(packagesToInstall []common.Package, templatePathP
 			envBaseUrl = DefaultBaseUrl
 		}
 
-		if templatePathPrefix == "" {
-			templatePathPrefix = DefaultTemplatePathPrefix
+		if packagePathPrefix == "" {
+			packagePathPrefix = DefaultPackagePathPrefix
 		}
 
 		path := strings.Join(
-			[]string{templatePathPrefix, pkg.Template},
+			[]string{packagePathPrefix, pkg.Template},
 			"/")
 		templateURL := fmt.Sprintf("%s%s?ref=%s", envBaseUrl, path, pkg.Ref)
 

--- a/pkg/pkg/install/install.go
+++ b/pkg/pkg/install/install.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-const DefaultBaseUrl = "git@github.com:oslokommune/golden-path-boilerplate.git//boilerplate"
-const DefaultTemplatePathPrefix = "terraform"
+const DefaultBaseUrl = "git@github.com:oslokommune/golden-path-boilerplate.git//"
+const DefaultTemplatePathPrefix = "boilerplate/terraform"
 
 func Run(pkgManifestFilename string, outputFolders []string) error {
 	cmds, err := CreateBoilerplateCommands(pkgManifestFilename, outputFolders)
@@ -113,10 +113,10 @@ func createBoilerPlateCommands(packagesToInstall []common.Package, templatePathP
 			templatePathPrefix = DefaultTemplatePathPrefix
 		}
 
-		url := strings.Join(
-			[]string{envBaseUrl, templatePathPrefix, pkg.Template},
+		path := strings.Join(
+			[]string{templatePathPrefix, pkg.Template},
 			"/")
-		templateURL := fmt.Sprintf("%s?ref=%s", url, pkg.Ref)
+		templateURL := fmt.Sprintf("%s%s?ref=%s", envBaseUrl, path, pkg.Ref)
 
 		cmdArgs := []string{
 			"--template-url", templateURL,

--- a/pkg/pkg/install/install.go
+++ b/pkg/pkg/install/install.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 )
 
-const DefaultBaseUrl = "git@github.com:oslokommune/golden-path-boilerplate.git//boilerplate/terraform"
+const DefaultBaseUrl = "git@github.com:oslokommune/golden-path-boilerplate.git//boilerplate"
+const DefaultTemplatePathPrefix = "terraform"
 
 func Run(pkgManifestFilename string, outputFolders []string) error {
 	cmds, err := CreateBoilerplateCommands(pkgManifestFilename, outputFolders)
@@ -75,7 +76,10 @@ func CreateBoilerplateCommands(pkgManifestFilename string, outputFolders []strin
 	}
 
 	// Install packages
-	cmds := createBoilerPlateCommands(packagesToInstall)
+	cmds, err := createBoilerPlateCommands(packagesToInstall, manifest.DefaultTemplatePathPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("creating boilerplate commands: %w", err)
+	}
 
 	return cmds, nil
 }
@@ -97,17 +101,22 @@ func filterPackages(packages []common.Package, outputFolders []string) []common.
 	return result
 }
 
-func createBoilerPlateCommands(packagesToInstall []common.Package) []*exec.Cmd {
+func createBoilerPlateCommands(packagesToInstall []common.Package, templatePathPrefix string) ([]*exec.Cmd, error) {
 	var cmds []*exec.Cmd
 	for _, pkg := range packagesToInstall {
-
-		var EnvBaseUrl = os.Getenv("BASE_URL")
-		var templateURL string
-		if EnvBaseUrl == "" {
-			templateURL = fmt.Sprintf("%s/%s?ref=%s", DefaultBaseUrl, pkg.Template, pkg.Ref)
-		} else {
-			templateURL = fmt.Sprintf("%s/%s?ref=%s", EnvBaseUrl, pkg.Template, pkg.Ref)
+		var envBaseUrl = os.Getenv("BASE_URL")
+		if envBaseUrl == "" {
+			envBaseUrl = DefaultBaseUrl
 		}
+
+		if templatePathPrefix == "" {
+			templatePathPrefix = DefaultTemplatePathPrefix
+		}
+
+		url := strings.Join(
+			[]string{envBaseUrl, templatePathPrefix, pkg.Template},
+			"/")
+		templateURL := fmt.Sprintf("%s?ref=%s", url, pkg.Ref)
 
 		cmdArgs := []string{
 			"--template-url", templateURL,
@@ -122,5 +131,6 @@ func createBoilerPlateCommands(packagesToInstall []common.Package) []*exec.Cmd {
 		cmd := exec.Command("boilerplate", cmdArgs...)
 		cmds = append(cmds, cmd)
 	}
-	return cmds
+
+	return cmds, nil
 }

--- a/pkg/pkg/install/install_test.go
+++ b/pkg/pkg/install/install_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 import (
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -27,7 +27,7 @@ func TestInstall(t *testing.T) {
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/terraform/app?ref=app-v6.1.1",
+					"--template-url", DefaultBaseUrl+"boilerplate/terraform/app?ref=app-v6.1.1",
 					"--output-folder", "out/app-hello",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -35,7 +35,7 @@ func TestInstall(t *testing.T) {
 				),
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/terraform/networking?ref=main",
+					"--template-url", DefaultBaseUrl+"boilerplate/terraform/networking?ref=main",
 					"--output-folder", "out/networking",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -50,7 +50,7 @@ func TestInstall(t *testing.T) {
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/terraform/app?ref=app-v6.1.1",
+					"--template-url", DefaultBaseUrl+"boilerplate/terraform/app?ref=app-v6.1.1",
 					"--output-folder", "out/app-hello",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -64,7 +64,7 @@ func TestInstall(t *testing.T) {
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/github-actions/terraform-on-changed-dirs?ref=main",
+					"--template-url", DefaultBaseUrl+"boilerplate/github-actions/terraform-on-changed-dirs?ref=main",
 					"--output-folder", "out/.github/workflows",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -86,7 +86,7 @@ func TestInstall(t *testing.T) {
 			cmds, err := CreateBoilerplateCommands(inputFile, tc.outputFolders)
 
 			// Then
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 
 			for i, cmd := range cmds {
 				assert.Equal(t, cmd.Path, tc.expectBoilerplateCommands[i].Path)

--- a/pkg/pkg/install/install_test.go
+++ b/pkg/pkg/install/install_test.go
@@ -27,7 +27,7 @@ func TestInstall(t *testing.T) {
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/app?ref=app-v6.1.1",
+					"--template-url", DefaultBaseUrl+"/terraform/app?ref=app-v6.1.1",
 					"--output-folder", "out/app-hello",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -35,7 +35,7 @@ func TestInstall(t *testing.T) {
 				),
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/networking?ref=main",
+					"--template-url", DefaultBaseUrl+"/terraform/networking?ref=main",
 					"--output-folder", "out/networking",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -50,11 +50,25 @@ func TestInstall(t *testing.T) {
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"/app?ref=app-v6.1.1",
+					"--template-url", DefaultBaseUrl+"/terraform/app?ref=app-v6.1.1",
 					"--output-folder", "out/app-hello",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
 					"--var-file", "config/app-hello.yml",
+				),
+			},
+		},
+		{
+			testName:                "Should install package correctly when template path prefix set",
+			packageManifestFilename: "packages-github-actions.yml",
+			expectBoilerplateCommands: []*exec.Cmd{
+				exec.Command(
+					"boilerplate",
+					"--template-url", DefaultBaseUrl+"/github-actions/terraform-on-changed-dirs?ref=main",
+					"--output-folder", "out/.github/workflows",
+					"--non-interactive",
+					"--var-file", "config/common-config.yml",
+					"--var-file", "config/terraform-on-changed-dirs.yml",
 				),
 			},
 		},

--- a/pkg/pkg/install/testdata/packages-github-actions.yml
+++ b/pkg/pkg/install/testdata/packages-github-actions.yml
@@ -1,4 +1,4 @@
-DefaultTemplatePathPrefix: "github-actions"
+DefaultTemplatePathPrefix: "boilerplate/github-actions"
 
 Packages:
   - Template: "terraform-on-changed-dirs"

--- a/pkg/pkg/install/testdata/packages-github-actions.yml
+++ b/pkg/pkg/install/testdata/packages-github-actions.yml
@@ -1,4 +1,4 @@
-DefaultTemplatePathPrefix: "boilerplate/github-actions"
+DefaultPackagePathPrefix: "boilerplate/github-actions"
 
 Packages:
   - Template: "terraform-on-changed-dirs"

--- a/pkg/pkg/install/testdata/packages-github-actions.yml
+++ b/pkg/pkg/install/testdata/packages-github-actions.yml
@@ -1,0 +1,9 @@
+DefaultTemplatePathPrefix: "github-actions"
+
+Packages:
+  - Template: "terraform-on-changed-dirs"
+    Ref: "main"
+    OutputFolder: "out/.github/workflows"
+    VarFiles:
+      - "config/common-config.yml"
+      - "config/terraform-on-changed-dirs.yml"


### PR DESCRIPTION
# Description

This is a proof of concept for a simple way to supporting github actions templates. We can discuss other designs / variable namings before applying. Some designs are discussed in https://github.com/oslokommune/golden-path-boilerplate/issues/339.

We might want more advanced capabilities later, but right now I wanted to keep things simple.

---

Design question: Should line 1 in the file below always be required, or should it default to `boilerplate/terraform`?

https://github.com/oslokommune/ok/blob/96793563334be8a7052b12e436c17877491b4527/pkg/pkg/install/testdata/packages-github-actions.yml#L1

Given above example, `ok` will use this template URL:
The value refer to a directory under `https://github.com/oslokommune/golden-path-boilerplate/tree/main/boilerplate/github-actions`.

Currently, if this line is omitted, `boilerplate/terraform` will be used as the template path prefix. We most often work with Terraform, so this makes sense to me.

# Motivation

https://github.com/oslokommune/golden-path-boilerplate/issues/339