### PR TITLE
fix: Support both path and url for BASE_URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,4 +81,5 @@ require (
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,9 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/pkg/install/install.go
+++ b/pkg/pkg/install/install.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oslokommune/ok/pkg/pkg/common"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -114,17 +115,14 @@ func createBoilerPlateCommands(packagesToInstall []common.Package, packagePathPr
 			packagePathPrefix = DefaultPackagePathPrefix
 		}
 
-		path := strings.Join(
-			[]string{packagePathPrefix, pkg.Template},
-			"/")
-
-		// envBaseUrl can be a URL or a path
 		var templateURL string
 		if isUrl(baseUrlOrPath) {
-			templateURL = fmt.Sprintf("%s%s?ref=%s", baseUrlOrPath, path, pkg.Ref)
-		} else {
-			templateURL = fmt.Sprintf("%s%s", baseUrlOrPath, path)
+			pathz := strings.Join(
+				[]string{packagePathPrefix, pkg.Template}, "/")
 
+			templateURL = fmt.Sprintf("%s%s?ref=%s", baseUrlOrPath, pathz, pkg.Ref)
+		} else {
+			templateURL = path.Join(baseUrlOrPath, packagePathPrefix, pkg.Template)
 		}
 
 		cmdArgs := []string{

--- a/pkg/pkg/install/install_test.go
+++ b/pkg/pkg/install/install_test.go
@@ -2,15 +2,12 @@ package install
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-)
-
-import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -20,6 +17,7 @@ func TestInstall(t *testing.T) {
 		packageManifestFilename   string
 		expectBoilerplateCommands []*exec.Cmd
 		outputFolders             []string
+		baseUrl                   string
 	}{
 		{
 			testName:                "Should install all packages from packages.yml",
@@ -40,6 +38,35 @@ func TestInstall(t *testing.T) {
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
 					"--var-file", "config/networking.yml",
+				),
+			},
+		},
+		{
+			testName:                "Should support URL in BASE_URL",
+			packageManifestFilename: "package.yml",
+			baseUrl:                 DefaultBaseUrl,
+			expectBoilerplateCommands: []*exec.Cmd{
+				exec.Command(
+					"boilerplate",
+					"--template-url", DefaultBaseUrl+"boilerplate/terraform/app?ref=app-v6.1.1",
+					"--output-folder", "out/app-hello",
+					"--non-interactive",
+					"--var-file", "config/common-config.yml",
+					"--var-file", "config/app-hello.yml",
+				),
+			},
+		}, {
+			testName:                "Should support file path in BASE_URL",
+			packageManifestFilename: "package.yml",
+			baseUrl:                 "../",
+			expectBoilerplateCommands: []*exec.Cmd{
+				exec.Command(
+					"boilerplate",
+					"--template-url", "../boilerplate/terraform/app",
+					"--output-folder", "out/app-hello",
+					"--non-interactive",
+					"--var-file", "config/common-config.yml",
+					"--var-file", "config/app-hello.yml",
 				),
 			},
 		},
@@ -83,7 +110,7 @@ func TestInstall(t *testing.T) {
 			require.Nil(t, err)
 
 			// When
-			cmds, err := CreateBoilerplateCommands(inputFile, tc.outputFolders)
+			cmds, err := CreateBoilerplateCommands(inputFile, tc.outputFolders, tc.baseUrl)
 
 			// Then
 			assert.Nil(t, err)

--- a/pkg/pkg/install/install_test.go
+++ b/pkg/pkg/install/install_test.go
@@ -44,11 +44,11 @@ func TestInstall(t *testing.T) {
 		{
 			testName:                "Should support URL in BASE_URL",
 			packageManifestFilename: "package.yml",
-			baseUrl:                 DefaultBaseUrl,
+			baseUrl:                 "git@github.com:oslokommune/SOMETHING_ELSE.git//",
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",
-					"--template-url", DefaultBaseUrl+"boilerplate/terraform/app?ref=app-v6.1.1",
+					"--template-url", "git@github.com:oslokommune/SOMETHING_ELSE.git//boilerplate/terraform/app?ref=app-v6.1.1",
 					"--output-folder", "out/app-hello",
 					"--non-interactive",
 					"--var-file", "config/common-config.yml",
@@ -58,7 +58,7 @@ func TestInstall(t *testing.T) {
 		}, {
 			testName:                "Should support file path in BASE_URL",
 			packageManifestFilename: "package.yml",
-			baseUrl:                 "../",
+			baseUrl:                 "..",
 			expectBoilerplateCommands: []*exec.Cmd{
 				exec.Command(
 					"boilerplate",

--- a/pkg/pkg/install/testdata/package.yml
+++ b/pkg/pkg/install/testdata/package.yml
@@ -1,0 +1,7 @@
+Packages:
+  - Template: "app"
+    Ref: "app-v6.1.1"
+    OutputFolder: "out/app-hello"
+    VarFiles:
+      - "config/common-config.yml"
+      - "config/app-hello.yml"


### PR DESCRIPTION
# Description

`BASE_URL` does not support local file system right now. It did a little while ago, but then it didn't support remote file systems. This PR fix so `ok` supports both.

Boilerplate interprets whether `--template-url` is file or URL. Then `ok pkg` must also do it, unless we are going to support extra arguments like `--use-file-system`. Since it's not very difficult, I chose to go the Boilerplate way now.

# Motivation

Fixes https://github.com/oslokommune/ok/issues/181.

* Support file system and URLs for BASE_URL.
* Simplicity for the user