### PR TITLE
feat: Add help message if GitHub auth fails

### DIFF
--- a/pkg/pkg/add/add.go
+++ b/pkg/pkg/add/add.go
@@ -2,6 +2,7 @@ package add
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
 	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
@@ -23,6 +24,10 @@ func Run(pkgManifestFilename string, templateName, outputFolder string) (*AddRes
 
 	latestReleases, err := githubreleases.GetLatestReleases()
 	if err != nil {
+		if strings.Contains(err.Error(), "secret not found in keyring") {
+			fmt.Println(githubreleases.HelpMessage)
+			fmt.Println()
+		}
 		return nil, fmt.Errorf("failed getting latest github releases: %w", err)
 	}
 

--- a/pkg/pkg/githubreleases/githubreleases.go
+++ b/pkg/pkg/githubreleases/githubreleases.go
@@ -11,6 +11,20 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+const HelpMessage = `
+GitHub token not found in keyring or environment variables.
+
+Steps to resolve:
+
+1. Ensure you have the latest GitHub CLI version, which in most cases should store the token in the OS keyring:
+   https://cli.github.com/
+
+2. Try logging in again with GitHub CLI:
+   gh auth login
+
+3. If you're still encountering issues, you can bypass the keyring by setting the token as an environment variable:
+   export GH_TOKEN=$(gh auth token)`
+
 type Release struct {
 	Component string
 	Version   string

--- a/pkg/pkg/update/update.go
+++ b/pkg/pkg/update/update.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
 	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
@@ -12,10 +13,13 @@ func Run(pkgManifestFilename string, packageName string) error {
 	if err != nil {
 		return fmt.Errorf("loading package manifest: %w", err)
 	}
-
 	latestReleases, err := githubreleases.GetLatestReleases()
 	if err != nil {
-		return fmt.Errorf("getting latest releases: %w", err)
+		if strings.Contains(err.Error(), "secret not found in keyring") {
+			fmt.Println(githubreleases.HelpMessage)
+			fmt.Println()
+		}
+		return fmt.Errorf("failed getting latest github releases: %w", err)
 	}
 
 	if packageName != "" {


### PR DESCRIPTION
```
go run ../main.go pkg update

GitHub token not found in keyring or environment variables.

Steps to resolve:

1. Ensure you have the latest GitHub CLI version, which in most cases should store the token in the OS keyring:
   https://cli.github.com/

2. Try logging in again with GitHub CLI:
   gh auth login

3. If you're still encountering issues, you can bypass the keyring by setting the token as an environment variable:
   export GH_TOKEN=$(gh auth token)

failed getting latest github releases: getting GitHub token: getting GitHub token from keyring: secret not found in keyring
exit status 1
```