### PR TITLE
feat: Add update check when running ok version

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	_ "embed"
 	"fmt"
+
+	"github.com/Masterminds/semver"
+	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +22,31 @@ var versionCmd = &cobra.Command{
 		fmt.Printf("Version: %s\n", VersionData.Version)
 		fmt.Printf("Date:    %s\n", VersionData.Date)
 		fmt.Printf("Commit:  %s\n", VersionData.Commit)
+
+		if VersionData.Version != "dev" {
+			latestVersion, err := githubreleases.GetLatestOkVersion()
+			if err != nil {
+				fmt.Printf("Error getting latest version: %v\n", err)
+				return
+			}
+
+			currentVersion, err := semver.NewVersion(VersionData.Version)
+			if err != nil {
+				fmt.Printf("Error parsing version string '%s': %v\n", VersionData.Version, err)
+				return
+			}
+
+			if currentVersion.LessThan(latestVersion) {
+				fmt.Printf("\nA new release of ok is available: %s → %s\n", currentVersion, latestVersion)
+				fmt.Println("\nTo update, run the following commands:")
+				fmt.Println("\nbrew update")
+				fmt.Println("brew upgrade ok")
+				fmt.Println("\nFor other update methods, see https://km.oslo.systems/setup/before-you-start/tools/ok/#updating")
+			} else if currentVersion.Equal(latestVersion) {
+				fmt.Println("\nYou are using the latest version.")
+			}
+		}
+
 	},
 }
 

--- a/pkg/pkg/githubreleases/githubreleases.go
+++ b/pkg/pkg/githubreleases/githubreleases.go
@@ -30,6 +30,27 @@ type Release struct {
 	Version   string
 }
 
+func GetLatestOkVersion() (*semver.Version, error) {
+	authToken, err := getGitHubToken()
+	if err != nil {
+		return nil, fmt.Errorf("getting GitHub token: %w", err)
+	}
+	client := github.NewClient(nil).WithAuthToken(authToken)
+
+	release, _, err := client.Repositories.GetLatestRelease(context.Background(), "oslokommune", "ok")
+	if err != nil {
+		return nil, fmt.Errorf("error getting latest release: %v", err)
+	}
+
+	versionTag := release.GetTagName()
+	versionSemver, err := semver.NewVersion(versionTag)
+	if err != nil {
+		return nil, fmt.Errorf("parsing version string '%s': %w", versionTag, err)
+	}
+
+	return versionSemver, nil
+}
+
 func GetLatestReleases() (map[string]string, error) {
 
 	authToken, err := getGitHubToken()


### PR DESCRIPTION
```sh
go run -ldflags "-X main.version=1.0.0 -X main.commit=abc1234 -X main.date=$(date +%Y-%m-%dT%H:%M:%SZ)" ../main.go version
```

Using old version:

```
Version: 1.0.0
Date:    2024-08-28T14:51:26Z
Commit:  abc1234

A new release of ok is available: 1.0.0 → 3.3.1

To update, run the following commands:

brew update
brew upgrade ok

For other update methods, see https://km.oslo.systems/setup/before-you-start/tools/ok/#updating
```

Using the latest version:

```sh
go run -ldflags "-X main.version=3.3.1 -X main.commit=abc1234 -X main.date=$(date +%Y-%m-%dT%H:%M:%SZ)" ../main.go version
```

```
Version: 3.3.1
Date:    2024-08-28T14:54:57Z
Commit:  abc1234

You are using the latest version.
```