### PR TITLE
feat: ok pkg tab-completions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,10 @@
 changelog:
   disable: true
 
+before:
+  hooks:
+    - ./scripts/completions.sh
+
 builds:
   - binary: ok
     goos:
@@ -23,3 +27,7 @@ brews:
     directory: Formula
     install: |
       bin.install "ok"
+    extra_install: |-
+      bash_completion.install "completions/ok.bash" => "ok"
+      zsh_completion.install "completions/ok.zsh" => "_ok"
+      fish_completion.install "completions/ok.fish"

--- a/cmd/pkg/add.go
+++ b/cmd/pkg/add.go
@@ -3,8 +3,10 @@ package pkg
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/oslokommune/ok/pkg/pkg/add"
+	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +20,8 @@ The output folder is useful when you need multiple instances of the same templat
 ok pkg add app ecommerce-website
 ok pkg add app ecommerce-api
 	`,
-	Args: cobra.RangeArgs(1, 2),
+	ValidArgsFunction: addTabCompletion,
+	Args:              cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		templateName := getArg(args, 0, "")
 		outputFolder := getArg(args, 1, templateName)
@@ -57,4 +60,30 @@ func findNonExistingConfigurationFiles(varFiles []string) []string {
 		}
 	}
 	return nonExisting
+}
+
+func addTabCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Only complete the first argument as the second argument is a self-assigned output folder
+	if len(args) == 0 {
+		return addTabCompletionApp(cmd, toComplete)
+	}
+
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+func addTabCompletionApp(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellCompDirective) {
+	latest, err := githubreleases.GetLatestReleases()
+	if err != nil {
+		cmd.PrintErrf("failed to load package manifest: %s\n", err)
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var completions []string
+	for template := range latest {
+		if strings.HasPrefix(template, toComplete) {
+			completions = append(completions, template)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/pkg/common.go
+++ b/cmd/pkg/common.go
@@ -1,3 +1,14 @@
 package pkg
 
 const PackagesManifestFilename = "packages.yml"
+
+// argsContainsElement checks if an element is in an array which
+// is used in the tab completion functions to filter out already selected elements
+func argsContainsElement[T comparable](arr []T, element T) bool {
+	for _, e := range arr {
+		if e == element {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/pkg/update.go
+++ b/cmd/pkg/update.go
@@ -2,7 +2,9 @@ package pkg
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/oslokommune/ok/pkg/pkg/common"
 	"github.com/oslokommune/ok/pkg/pkg/update"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +17,8 @@ If a package name is provided, only that package will be updated.
 If no package name is provided, all packages will be updated.`,
 	Example: `  ok pkg update
   ok pkg update my-package`,
-	Args: cobra.MaximumNArgs(1),
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: updateTabCompletion,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var packageName string
 		if len(args) == 1 {
@@ -35,4 +38,24 @@ If no package name is provided, all packages will be updated.`,
 
 		return nil
 	},
+}
+
+func updateTabCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// No completion if there are more than one argument
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	manifest, err := common.LoadPackageManifest(PackagesManifestFilename)
+	if err != nil {
+		cmd.PrintErrf("failed to load package manifest: %s\n", err)
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var completions []string
+	for _, p := range manifest.Packages {
+		if strings.HasPrefix(p.OutputFolder, toComplete) {
+			completions = append(completions, p.OutputFolder)
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+rm -rf completions
+mkdir completions
+for sh in bash zsh fish; do
+	go run main.go completion "$sh" >"completions/ok.$sh"
+done


### PR DESCRIPTION
Support tab-completion for
- `ok pkg add` *tab* to see all available github releases
- `ok pkg update` *tab* to see all output folders in your packages.yml
- `ok pkg install` *tab* to see all output folders in your packages.yml

This does not automatically apply tab-completions in your shell.
It is possible to let brew install this completion script for you, but I have not yet had time to look into that.


~For now you have the ability to source the completions directly in the terminal session.~

I made an attempt at installing completions by default
- [.goreleaser generate completions](https://github.com/oslokommune/ok/pull/208/commits/fcb599e3d89d1e53dafb96c639eb3229f256fe5a#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R7)
- [.goreleaser bundle completion files](https://github.com/oslokommune/ok/pull/208/commits/fcb599e3d89d1e53dafb96c639eb3229f256fe5a#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R30)

