### PR TITLE
ci: specify goreleaser config version and schema

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
 # The changelog is managed by release-please
 changelog:
   disable: true


### PR DESCRIPTION
GoReleaser klager over uspesifisert versjon i `.goreleaser` konfigurasjon.
Se logger her: https://github.com/oslokommune/ok/actions/runs/10772486725/job/29870241049#step:4:17

Legger til versjon samt referanse til jsonschema i konfigurasjonsfil.