### PR TITLE
fix: output command to connect to ECS task instead of trying to execute it in go-code

### DIFF
--- a/cmd/aws/exec.go
+++ b/cmd/aws/exec.go
@@ -13,11 +13,10 @@ var EcsExecCommand = &cobra.Command{
 	Short: "Get a shell to a running ECS task",
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cluster, err := aws.Exec()
+		_, err := aws.Exec()
 		if err != nil {
 			return fmt.Errorf("list clusters: %w", err)
 		}
-		fmt.Println("Selected cluster: ", cluster)
 		return nil
 	},
 }

--- a/pkg/aws/exec.go
+++ b/pkg/aws/exec.go
@@ -8,6 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/magefile/mage/sh"
+	"strings"
 )
 
 func listClusters() ([]string, error) {
@@ -89,13 +92,22 @@ func getTaskDetails(clusterName, taskId string) (*types.Task, error) {
 }
 
 func outputExecuteCommand(clusterName, taskId, containerName string) error {
-	fmt.Printf(">> To execute command on the container, run the following:\n\n")
-	fmt.Printf("aws ecs execute-command ")
-	fmt.Printf("--cluster %s ", clusterName)
-	fmt.Printf("--task %s ", taskId)
-	fmt.Printf("--container %s ", containerName)
-	fmt.Printf("--command \"/bin/sh\" ")
-	fmt.Print("--interactive\n")
+	combinedArgs := []string{
+		"ecs",
+		"execute-command",
+		"--cluster", clusterName,
+		"--task", taskId,
+		"--container", containerName,
+		"--command", "/bin/sh",
+		"--interactive",
+	}
+	green := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	fmt.Println("------------------------------------------------------------------------------------------")
+	fmt.Println("Running aws command:")
+	fmt.Println(green.Render("aws " + strings.Join(combinedArgs, " ")))
+	fmt.Println("------------------------------------------------------------------------------------------")
+
+	_ = sh.RunV("aws", combinedArgs...)
 	return nil
 }
 


### PR DESCRIPTION
# Description

Move from trying to execute `/bin/sh` via go-code to build up a command that the user can use to connect to the ECS task using the AWS tools that are built to handle this.

Example usage:
```
ok aws ecs-exec
# select cluster/task/container
>> To execute command on the container, run the following:

aws ecs execute-command --cluster arn:aws:ecs:eu-west-1:932360772598:cluster/pirates-dev --task arn:aws:ecs:eu-west-1:932360772598:task/pirates-dev/942649740a2c419caa00dd279ab51e4a --container too-tikki --command "/bin/sh" --interactive
```
User copies the `aws ecs execute-command` line and the `aws` CLI tool deals with session manager and handling the connection to the ECS task

The user can then change the command if need be:
```
aws ecs execute-command --cluster arn:aws:ecs:eu-west-1:932360772598:cluster/pirates-dev --task arn:aws:ecs:eu-west-1:932360772598:task/pirates-dev/942649740a2c419caa00dd279ab51e4a --container too-tikki --command "tail -f /var/log/foobar.txt" --interactive
```

Outputting the command and piping it to a new shell (if you remove the `>> To execute command on the container, run the following:` output):
```
ok aws ecs-exec | sh
```
is not working since we spawn a new shell

The solution then is to do: `eval $(ok aws ecs-exec)`, but this is not a good practice

We can look at naming convention for the command.

# Motivation

Building, and maintaining, functionality that exists in the `aws` CLI tool should not be a core part of what the `ok` tool should focus on. 