### PR TITLE
fix: update templates with slash

### DIFF
--- a/pkg/pkg/update/migrate_config/metadata/json_schema.go
+++ b/pkg/pkg/update/migrate_config/metadata/json_schema.go
@@ -76,7 +76,7 @@ func parseMetadata(firstLine string) (JsonSchema, error) {
 }
 
 func parseSchemaLine(line string) (string, string, error) {
-	re := regexp.MustCompile(`\.schemas/(\w+)-(\S+)\.schema\.json`)
+	re := regexp.MustCompile(`\.schemas/([\w-]+)-(\S+)\.schema\.json`)
 
 	matches := re.FindStringSubmatch(line)
 	if len(matches) != 3 {

--- a/pkg/pkg/update/update.go
+++ b/pkg/pkg/update/update.go
@@ -111,9 +111,11 @@ func updateSchemaConfiguration(ctx context.Context, manifest common.PackageManif
 		return fmt.Errorf("getting GitHub client: %w", err)
 	}
 
-	fmt.Printf("Updating schema configuration files: ")
+	fmt.Println("Updating schema configuration files:")
 
-	for i, pkg := range selectedPackages {
+	for _, pkg := range selectedPackages {
+		fmt.Printf("- %s\n", pkg.OutputFolder)
+
 		_, err := pkg.PackageVersion()
 		if err != nil {
 			// pkg.Ref might be "main". To keep code simple, we avoid dealing with non-semver versions.
@@ -123,12 +125,6 @@ func updateSchemaConfiguration(ctx context.Context, manifest common.PackageManif
 		varFile, ok := getLastVarFile(pkg)
 		if !ok {
 			continue
-		}
-
-		if i > 0 {
-			fmt.Printf(", %s", pkg.OutputFolder)
-		} else {
-			fmt.Printf("%s", pkg.OutputFolder)
 		}
 
 		// Get current JSON schema for the package
@@ -161,8 +157,6 @@ func updateSchemaConfiguration(ctx context.Context, manifest common.PackageManif
 			return fmt.Errorf("creating or updating configuration file: %w", err)
 		}
 	}
-
-	fmt.Println()
 
 	return nil
 }


### PR DESCRIPTION
# Description

Fixes this:

```sh
$ ok pkg update rds-bastion
Updating schema configuration files: rds-bastionupdating packages: parsing first line of file '_config/rds-bastion.yml': parsing metadata from line '# yaml-language-server: $schema=.schemas/rds-bastion-v3.4.0.schema.json': creating semver: Invalid Semantic Version
```

Errors:
* Cannot update templates with template name containing dash, for instance `rds-bastion`. Fixed by updating regex.
* The error gets entangled with the output. Fixed this by putting output on separate lines.
 