### PR TITLE
fix: `ok pkg update` writes old template version to var file

### DIFF
--- a/.run/mage test.run.xml
+++ b/.run/mage test.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mage test" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="mage test" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/cmd/pkg/testdata/bump-ref-field/expected/config/app-hello.yml
+++ b/cmd/pkg/testdata/bump-ref-field/expected/config/app-hello.yml
@@ -10,6 +10,13 @@ ServiceConnect:
   Enable: true
 AlbHostRouting:
   Enable: true
+  Internal: false
+  Subdomain:
+    Enable: true
+    TargetGroupTargetStickiness: false
+  ApexDomain:
+    Enable: false
+    TargetGroupTargetStickiness: false
 DatabaseConnectivity:
   Enable: true
 OpenTelemetrySidecar:

--- a/cmd/pkg/testdata/bump-ref-field/expected/config/app-hello.yml
+++ b/cmd/pkg/testdata/bump-ref-field/expected/config/app-hello.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=.schemas/app-v9.0.0.schema.json
+StackName: "app-hello"
+app-data.StackName: "app-hello-data"
+AppName: "hello"
+AppEcsExec: true
+AppReadOnlyRootFileSystem: true
+ExampleImage:
+  Enable: true
+ServiceConnect:
+  Enable: true
+AlbHostRouting:
+  Enable: true
+DatabaseConnectivity:
+  Enable: true
+OpenTelemetrySidecar:
+  Enable: true
+VpcEndpoints:
+  Enable: true
+Xray:
+  Enable: true
+DailyShutdown:
+  Enable: true
+IamForCicd:
+  Enable: true
+  AppGitHubRepo: pirates-apps
+  IacGitHubRepo: pirates-iac
+  #AssumableCdRole: false

--- a/cmd/pkg/testdata/bump-ref-field/expected/config/common-config.yml
+++ b/cmd/pkg/testdata/bump-ref-field/expected/config/common-config.yml
@@ -1,0 +1,4 @@
+AccountId: "123456789012"
+Region: "eu-west-1"
+Team: "kjoremiljo"
+Environment: "test-dev"

--- a/cmd/pkg/testdata/bump-ref-field/input/json-schemas/app-v9.0.0.schema.json
+++ b/cmd/pkg/testdata/bump-ref-field/input/json-schemas/app-v9.0.0.schema.json
@@ -1,0 +1,433 @@
+{
+  "$id": "boilerplate/terraform/app-app-v9.6.0",
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "AlbHostRouting": {
+      "type": "object",
+      "description": "Add ALB host routing. See:\n- https://github.com/oslokommune/golden-path-iac/tree/main/terraform/modules/alb-tg-host-routing\n- https://github.com/oslokommune/golden-path-iac/tree/main/terraform/modules/alb-tg-host-routing-apex\n",
+      "default": {
+        "ApexDomain": {
+          "Enable": false,
+          "TargetGroupTargetStickiness": false
+        },
+        "Enable": false,
+        "Internal": true,
+        "Subdomain": {
+          "Enable": false,
+          "TargetGroupTargetStickiness": false
+        }
+      },
+      "properties": {
+        "ApexDomain": {
+          "type": "object",
+          "default": {
+            "Enable": false,
+            "TargetGroupTargetStickiness": false
+          }
+        },
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        },
+        "Internal": {
+          "type": "boolean",
+          "default": true
+        },
+        "Subdomain": {
+          "type": "object",
+          "default": {
+            "Enable": false,
+            "TargetGroupTargetStickiness": false
+          }
+        }
+      },
+      "required": [
+        "Enable",
+        "Internal",
+        "Subdomain",
+        "ApexDomain"
+      ]
+    },
+    "AlbHostRouting.ApexDomain": {
+      "type": "object",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": {
+        "Enable": false,
+        "TargetGroupTargetStickiness": false
+      }
+    },
+    "AlbHostRouting.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": false
+    },
+    "AlbHostRouting.Internal": {
+      "type": "boolean",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": true
+    },
+    "AlbHostRouting.Subdomain": {
+      "type": "object",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": {
+        "Enable": false,
+        "TargetGroupTargetStickiness": false
+      }
+    },
+    "AppEcsExec": {
+      "type": "boolean",
+      "description": "Enable ECS Exec.",
+      "default": false
+    },
+    "AppName": {
+      "type": "string",
+      "description": "Application name"
+    },
+    "AppReadOnlyRootFileSystem": {
+      "type": "boolean",
+      "description": "Enable read-only root filesystem.",
+      "default": false
+    },
+    "AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "DailyShutdown": {
+      "type": "object",
+      "description": "Enable daily shutdown of the ECS service.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "DailyShutdown.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of DailyShutdown",
+      "default": false
+    },
+    "DatabaseConnectivity": {
+      "type": "object",
+      "description": "Add database.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "DatabaseConnectivity.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of DatabaseConnectivity",
+      "default": false
+    },
+    "Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "ExampleImage": {
+      "type": "object",
+      "description": "Use Nginx example image.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "ExampleImage.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of ExampleImage",
+      "default": false
+    },
+    "IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AppGitHubRepo": null,
+        "AssumableCdRole": false,
+        "Enable": false,
+        "IacGitHubRepo": null
+      },
+      "properties": {
+        "AppGitHubRepo": {},
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        },
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        },
+        "IacGitHubRepo": {}
+      },
+      "required": [
+        "AssumableCdRole",
+        "Enable",
+        "AppGitHubRepo",
+        "IacGitHubRepo"
+      ]
+    },
+    "IamForCicd.AppGitHubRepo": {
+      "description": "Override single parameter of IamForCicd"
+    },
+    "IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of IamForCicd",
+      "default": false
+    },
+    "IamForCicd.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of IamForCicd",
+      "default": false
+    },
+    "IamForCicd.IacGitHubRepo": {
+      "description": "Override single parameter of IamForCicd"
+    },
+    "IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "OpenTelemetrySidecar": {
+      "type": "object",
+      "description": "Add OpenTelemetry sidecar to collect Prometheus metrics.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "OpenTelemetrySidecar.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of OpenTelemetrySidecar",
+      "default": false
+    },
+    "Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "ServiceConnect": {
+      "type": "object",
+      "description": "Enable Amazon ECS Service Connect for service discovery. Enable this if you want to easily discover and connect to other services in your ECS cluster.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "ServiceConnect.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of ServiceConnect",
+      "default": false
+    },
+    "StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Terragrunt",
+      "default": false
+    },
+    "VpcEndpoints": {
+      "type": "object",
+      "description": "Enable VPC endpoints.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "VpcEndpoints.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of VpcEndpoints",
+      "default": false
+    },
+    "Xray": {
+      "type": "object",
+      "description": "Enable AWS X-Ray tracing.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "Xray.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Xray",
+      "default": false
+    },
+    "app-data.AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "app-data.AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "app-data.Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "app-data.IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AssumableCdRole": false
+      },
+      "properties": {
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "AssumableCdRole"
+      ]
+    },
+    "app-data.IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of app-data.IamForCicd",
+      "default": false
+    },
+    "app-data.IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "app-data.Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "app-data.S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "app-data.StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "app-data.Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "app-data.TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "app-data.Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "app-data.Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of app-data.Terragrunt",
+      "default": false
+    }
+  },
+  "required": [
+    "StackName",
+    "app-data.StackName"
+  ]
+}

--- a/cmd/pkg/testdata/bump-ref-field/input/json-schemas/load-balancing-alb-v4.0.0.schema.json
+++ b/cmd/pkg/testdata/bump-ref-field/input/json-schemas/load-balancing-alb-v4.0.0.schema.json
@@ -1,0 +1,219 @@
+{
+  "$id": "boilerplate/terraform/load-balancing-alb-load-balancing-alb-v3.4.0",
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "Dns": {
+      "type": "object",
+      "description": "If Enable is true, a Route 53 record will be created for the ALB. If EnableHttps is true, a certificate will be configured for the domain and the ALB will be configured to use it. All HTTP requests will be redirected to HTTPS.",
+      "default": {
+        "Enable": true,
+        "EnableHttps": true
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": true
+        },
+        "EnableHttps": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "required": [
+        "Enable",
+        "EnableHttps"
+      ]
+    },
+    "Dns.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Dns",
+      "default": true
+    },
+    "Dns.EnableHttps": {
+      "type": "boolean",
+      "description": "Override single parameter of Dns",
+      "default": true
+    },
+    "Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AssumableCdRole": false
+      },
+      "properties": {
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "AssumableCdRole"
+      ]
+    },
+    "IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of IamForCicd",
+      "default": false
+    },
+    "IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "Internal": {
+      "type": "boolean",
+      "description": "If true, the Application Load Balancer will be internal. If false, it will be internet-facing.",
+      "default": true
+    },
+    "Name": {
+      "type": "string",
+      "description": "Application Load Balancer name",
+      "default": "main"
+    },
+    "Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Terragrunt",
+      "default": false
+    },
+    "load-balancing-alb-data.AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "load-balancing-alb-data.AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "load-balancing-alb-data.Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "load-balancing-alb-data.IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AssumableCdRole": false
+      },
+      "properties": {
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "AssumableCdRole"
+      ]
+    },
+    "load-balancing-alb-data.IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of load-balancing-alb-data.IamForCicd",
+      "default": false
+    },
+    "load-balancing-alb-data.IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "load-balancing-alb-data.Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "load-balancing-alb-data.S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "load-balancing-alb-data.StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "load-balancing-alb-data.Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "load-balancing-alb-data.TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "load-balancing-alb-data.Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "load-balancing-alb-data.Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of load-balancing-alb-data.Terragrunt",
+      "default": false
+    }
+  },
+  "required": [
+    "StackName",
+    "load-balancing-alb-data.StackName"
+  ]
+}

--- a/cmd/pkg/testdata/bump-schema-version/expected/config/app-hello.yml
+++ b/cmd/pkg/testdata/bump-schema-version/expected/config/app-hello.yml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=.schemas/app-v9.0.0.schema.json
+StackName: "app-hello"
+app-data.StackName: "app-hello-data"
+AppName: "hello"
+AppEcsExec: true
+AppReadOnlyRootFileSystem: true
+ExampleImage:
+  Enable: true
+ServiceConnect:
+  Enable: true
+AlbHostRouting:
+  Enable: true
+  Internal: false
+  Subdomain:
+    Enable: true
+    TargetGroupTargetStickiness: false
+  ApexDomain:
+    Enable: false
+    TargetGroupTargetStickiness: false
+DatabaseConnectivity:
+  Enable: true
+OpenTelemetrySidecar:
+  Enable: true
+VpcEndpoints:
+  Enable: true
+Xray:
+  Enable: true
+DailyShutdown:
+  Enable: true
+IamForCicd:
+  Enable: true
+  AppGitHubRepo: pirates-apps
+  IacGitHubRepo: pirates-iac
+  #AssumableCdRole: false

--- a/cmd/pkg/testdata/bump-schema-version/expected/config/common-config.yml
+++ b/cmd/pkg/testdata/bump-schema-version/expected/config/common-config.yml
@@ -1,0 +1,4 @@
+AccountId: "123456789012"
+Region: "eu-west-1"
+Team: "kjoremiljo"
+Environment: "test-dev"

--- a/cmd/pkg/testdata/bump-schema-version/expected/packages.yml
+++ b/cmd/pkg/testdata/bump-schema-version/expected/packages.yml
@@ -1,0 +1,7 @@
+Packages:
+    - OutputFolder: app-hello
+      Template: app
+      Ref: app-v9.0.0
+      VarFiles:
+        - config/common-config.yml
+        - config/app-hello.yml

--- a/cmd/pkg/testdata/bump-schema-version/input/boilerplate/terraform/app/boilerplate.yml
+++ b/cmd/pkg/testdata/bump-schema-version/input/boilerplate/terraform/app/boilerplate.yml
@@ -1,0 +1,243 @@
+variables:
+  - name: TemplateVersion
+    type: string
+    description: Internal tracking of template version - do NOT edit
+    default: 9.7.1
+  - name: AppName
+    description: Application name
+    type: string
+  - name: AppReadOnlyRootFileSystem
+    description: Enable read-only root filesystem.
+    type: bool
+    default: false
+  - name: AppEcsExec
+    description: Enable ECS Exec.
+    type: bool
+    default: false
+  - name: ExampleImage
+    description: Use Nginx example image.
+    type: map
+    default:
+      Enable: false
+  - name: AlbHostRouting
+    description: >
+      Add ALB host routing. See:
+
+      -
+      https://github.com/oslokommune/golden-path-iac/tree/main/terraform/modules/alb-tg-host-routing
+
+      -
+      https://github.com/oslokommune/golden-path-iac/tree/main/terraform/modules/alb-tg-host-routing-apex
+    type: map
+    default:
+      Enable: false
+      Internal: true
+      Subdomain:
+        Enable: false
+        TargetGroupTargetStickiness: false
+      ApexDomain:
+        Enable: false
+        TargetGroupTargetStickiness: false
+  - name: DatabaseConnectivity
+    description: Add database.
+    type: map
+    default:
+      Enable: false
+  - name: OpenTelemetrySidecar
+    description: Add OpenTelemetry sidecar to collect Prometheus metrics.
+    type: map
+    default:
+      Enable: false
+  - name: Xray
+    description: Enable AWS X-Ray tracing.
+    type: map
+    default:
+      Enable: false
+  - name: VpcEndpoints
+    description: Enable VPC endpoints.
+    type: map
+    default:
+      Enable: false
+  - name: ServiceConnect
+    description: >-
+      Enable Amazon ECS Service Connect for service discovery. Enable this if
+      you want to easily discover and connect to other services in your ECS
+      cluster.
+    type: map
+    default:
+      Enable: false
+  - name: DailyShutdown
+    description: Enable daily shutdown of the ECS service.
+    type: map
+    default:
+      Enable: false
+  - name: IamForCicd
+    description: Enable IAM roles for CI/CD.
+    type: map
+    default:
+      Enable: false
+      AppGitHubRepo: null
+      IacGitHubRepo: null
+      AssumableCdRole: false
+  - name: Terragrunt
+    description: |-
+      Enable Terragrunt.
+      This is a experimental feature and should not be used in production.
+    type: map
+    default:
+      Enable: false
+skip_files:
+  - if: >-
+      {{ list outputFolder "__gp_config_app_image.auto.tfvars.json" | join "/" |
+      pathExists }}
+    path: __gp_config_app_image.auto.tfvars.json
+  - if: '{{ list outputFolder "config_override.tf" | join "/" | pathExists }}'
+    path: config_override.tf
+  - if: '{{ list outputFolder "terragrunt_custom.hcl" | join "/" | pathExists }}'
+    path: terragrunt_custom.hcl
+  - path: README.md
+  - path: CHANGELOG*.md
+partials:
+  - ../../partials/do-not-edit.txt
+  - ../partials/_config.tf
+dependencies:
+  - name: versions
+    template-url: ../versions
+    output-folder: .
+  - name: app-data
+    template-url: ../app-data
+    output-folder: '{{ outputFolder }}-data'
+hooks:
+  before:
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/_config_override.tf'
+        - '{{ outputFolder }}/__gp_config_override.tf'
+      skip: |-
+        {{ or
+          (list outputFolder "__gp__config_override.tf" | join "/" |pathExists)
+          (not (list outputFolder "_config_override.tf" | join "/" | pathExists))
+        }}
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/__gp_config_override.tf'
+        - '{{ outputFolder }}/config_override.tf'
+      skip: |-
+        {{ or
+          (list outputFolder "config_override.tf" | join "/" |pathExists)
+          (not (list outputFolder "__gp_config_override.tf" | join "/" | pathExists))
+        }}
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/_config_override.tf'
+        - '{{ outputFolder }}/config_override.tf'
+      skip: |-
+        {{ or
+          (list outputFolder "config_override.tf" | join "/" |pathExists)
+          (not (list outputFolder "_config_override.tf" | join "/" | pathExists))
+        }}
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/_config_app_image.auto.tfvars.json'
+        - '{{ outputFolder }}/__gp_config_app_image.auto.tfvars.json'
+      skip: |-
+        {{ or
+          (list outputFolder "__gp_config_app_image.auto.tfvars.json" | join "/" | pathExists)
+          (not (list outputFolder "_config_app_image.auto.tfvars.json" | join "/" | pathExists))
+        }}
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/_gp_app_alb_tg_host_routing_override.tf'
+        - '{{ outputFolder }}/_gp_alb_tg_host_routing_override.tf'
+      skip: |-
+        {{ or
+          (list outputFolder "_gp_alb_tg_host_routing_override.tf" | join "/" | pathExists)
+          (not (list outputFolder "_gp_app_alb_tg_host_routing_override.tf" | join "/" | pathExists))
+        }}
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/_gp_app_ecs_service_override.tf'
+        - '{{ outputFolder }}/_gp_ecs_service_override.tf'
+      skip: |-
+        {{ or
+          (list outputFolder "_gp_ecs_service_override.tf" | join "/" | pathExists)
+          (not (list outputFolder "_gp_app_ecs_service_override.tf" | join "/" | pathExists))
+        }}
+    - command: mv
+      args:
+        - '-f'
+        - '{{ outputFolder }}/_gp_app_security_groups_override.tf'
+        - '{{ outputFolder }}/_gp_security_groups_override.tf'
+      skip: |-
+        {{ or
+          (list outputFolder "_gp_security_groups_override.tf" | join "/" | pathExists)
+          (not (list outputFolder "_gp_app_security_groups_override.tf" | join "/" | pathExists))
+        }}
+    - command: rm
+      args:
+        - '-f'
+        - '{{ outputFolder }}/app_alb_tg_host_routing.tf'
+        - '{{ outputFolder }}/app_ecs_container_definition_main.tf'
+        - '{{ outputFolder }}/app_ecs_otel_collector_sidecar.tf'
+        - '{{ outputFolder }}/app_ecs_service.tf'
+        - '{{ outputFolder }}/app_iam_cicd_policies.tf'
+        - '{{ outputFolder }}/app_iam_cicd_roles.tf'
+        - '{{ outputFolder }}/app_security_groups.tf'
+        - '{{ outputFolder }}/_config_app_image.auto.tfvars.json'
+        - '{{ outputFolder }}/_config.tf'
+        - '{{ outputFolder }}/_dependencies.tf'
+        - '{{ outputFolder }}/_variables.tf'
+        - '{{ outputFolder }}/__gp_config_override.tf'
+        - '{{ outputFolder }}/_gp_app_alb_tg_host_routing.tf'
+        - '{{ outputFolder }}/_gp_app_ecs_container_definition_main.tf'
+        - '{{ outputFolder }}/_gp_app_ecs_otel_collector_sidecar.tf'
+        - '{{ outputFolder }}/_gp_app_ecs_service.tf'
+        - '{{ outputFolder }}/_gp_app_iam_cicd_policies.tf'
+        - '{{ outputFolder }}/_gp_app_iam_cicd_roles.tf'
+        - '{{ outputFolder }}/_gp_app_security_groups.tf'
+        - '{{ outputFolder }}/_gp_app_iam_cd_assumable_role.tf'
+    - command: find
+      args:
+        - '{{ outputFolder }}'
+        - (
+        - '-name'
+        - _gp_*.tf
+        - '-o'
+        - '-name'
+        - __gp_*.tf
+        - )
+        - '!'
+        - '-name'
+        - '*_override.tf'
+        - '-exec'
+        - rm
+        - '{}'
+        - ;
+  after:
+    - command: terraform
+      args:
+        - fmt
+      dir: '{{ outputFolder }}'
+    - command: terragrunt
+      args:
+        - hclfmt
+      dir: '{{ outputFolder }}'
+      skip: '{{ if not .Terragrunt.Enable }}true{{ else }}false{{ end }}'
+    - command: sh
+      args:
+        - '-c'
+        - >-
+          grep -rl "x-boilerplate-delete" . --include="*.tf"
+          --include="*.tfvars.json" --include="*.sh" --include="*.hcl" | xargs
+          --no-run-if-empty rm
+      dir: '{{ outputFolder }}'
+    - command: rmdir
+      args:
+        - '{{ outputFolder }}/bin'
+      skip: '{{ .IamForCicd.Enable }}'

--- a/cmd/pkg/testdata/bump-schema-version/input/config/app-hello.yml
+++ b/cmd/pkg/testdata/bump-schema-version/input/config/app-hello.yml
@@ -1,0 +1,26 @@
+StackName: "app-hello"
+app-data.StackName: "app-hello-data"
+AppName: "hello"
+AppEcsExec: true
+AppReadOnlyRootFileSystem: true
+ExampleImage:
+  Enable: true
+ServiceConnect:
+  Enable: true
+AlbHostRouting:
+  Enable: true
+DatabaseConnectivity:
+  Enable: true
+OpenTelemetrySidecar:
+  Enable: true
+VpcEndpoints:
+  Enable: true
+Xray:
+  Enable: true
+DailyShutdown:
+  Enable: true
+IamForCicd:
+  Enable: true
+  AppGitHubRepo: pirates-apps
+  IacGitHubRepo: pirates-iac
+  #AssumableCdRole: false

--- a/cmd/pkg/testdata/bump-schema-version/input/config/common-config.yml
+++ b/cmd/pkg/testdata/bump-schema-version/input/config/common-config.yml
@@ -1,0 +1,4 @@
+AccountId: "123456789012"
+Region: "eu-west-1"
+Team: "kjoremiljo"
+Environment: "test-dev"

--- a/cmd/pkg/testdata/bump-schema-version/input/json-schemas/app-v9.0.0.schema.json
+++ b/cmd/pkg/testdata/bump-schema-version/input/json-schemas/app-v9.0.0.schema.json
@@ -1,0 +1,433 @@
+{
+  "$id": "boilerplate/terraform/app-app-v9.6.0",
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "AlbHostRouting": {
+      "type": "object",
+      "description": "Add ALB host routing. See:\n- https://github.com/oslokommune/golden-path-iac/tree/main/terraform/modules/alb-tg-host-routing\n- https://github.com/oslokommune/golden-path-iac/tree/main/terraform/modules/alb-tg-host-routing-apex\n",
+      "default": {
+        "ApexDomain": {
+          "Enable": false,
+          "TargetGroupTargetStickiness": false
+        },
+        "Enable": false,
+        "Internal": true,
+        "Subdomain": {
+          "Enable": false,
+          "TargetGroupTargetStickiness": false
+        }
+      },
+      "properties": {
+        "ApexDomain": {
+          "type": "object",
+          "default": {
+            "Enable": false,
+            "TargetGroupTargetStickiness": false
+          }
+        },
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        },
+        "Internal": {
+          "type": "boolean",
+          "default": true
+        },
+        "Subdomain": {
+          "type": "object",
+          "default": {
+            "Enable": false,
+            "TargetGroupTargetStickiness": false
+          }
+        }
+      },
+      "required": [
+        "Enable",
+        "Internal",
+        "Subdomain",
+        "ApexDomain"
+      ]
+    },
+    "AlbHostRouting.ApexDomain": {
+      "type": "object",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": {
+        "Enable": false,
+        "TargetGroupTargetStickiness": false
+      }
+    },
+    "AlbHostRouting.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": false
+    },
+    "AlbHostRouting.Internal": {
+      "type": "boolean",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": true
+    },
+    "AlbHostRouting.Subdomain": {
+      "type": "object",
+      "description": "Override single parameter of AlbHostRouting",
+      "default": {
+        "Enable": false,
+        "TargetGroupTargetStickiness": false
+      }
+    },
+    "AppEcsExec": {
+      "type": "boolean",
+      "description": "Enable ECS Exec.",
+      "default": false
+    },
+    "AppName": {
+      "type": "string",
+      "description": "Application name"
+    },
+    "AppReadOnlyRootFileSystem": {
+      "type": "boolean",
+      "description": "Enable read-only root filesystem.",
+      "default": false
+    },
+    "AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "DailyShutdown": {
+      "type": "object",
+      "description": "Enable daily shutdown of the ECS service.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "DailyShutdown.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of DailyShutdown",
+      "default": false
+    },
+    "DatabaseConnectivity": {
+      "type": "object",
+      "description": "Add database.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "DatabaseConnectivity.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of DatabaseConnectivity",
+      "default": false
+    },
+    "Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "ExampleImage": {
+      "type": "object",
+      "description": "Use Nginx example image.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "ExampleImage.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of ExampleImage",
+      "default": false
+    },
+    "IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AppGitHubRepo": null,
+        "AssumableCdRole": false,
+        "Enable": false,
+        "IacGitHubRepo": null
+      },
+      "properties": {
+        "AppGitHubRepo": {},
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        },
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        },
+        "IacGitHubRepo": {}
+      },
+      "required": [
+        "AssumableCdRole",
+        "Enable",
+        "AppGitHubRepo",
+        "IacGitHubRepo"
+      ]
+    },
+    "IamForCicd.AppGitHubRepo": {
+      "description": "Override single parameter of IamForCicd"
+    },
+    "IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of IamForCicd",
+      "default": false
+    },
+    "IamForCicd.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of IamForCicd",
+      "default": false
+    },
+    "IamForCicd.IacGitHubRepo": {
+      "description": "Override single parameter of IamForCicd"
+    },
+    "IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "OpenTelemetrySidecar": {
+      "type": "object",
+      "description": "Add OpenTelemetry sidecar to collect Prometheus metrics.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "OpenTelemetrySidecar.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of OpenTelemetrySidecar",
+      "default": false
+    },
+    "Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "ServiceConnect": {
+      "type": "object",
+      "description": "Enable Amazon ECS Service Connect for service discovery. Enable this if you want to easily discover and connect to other services in your ECS cluster.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "ServiceConnect.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of ServiceConnect",
+      "default": false
+    },
+    "StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Terragrunt",
+      "default": false
+    },
+    "VpcEndpoints": {
+      "type": "object",
+      "description": "Enable VPC endpoints.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "VpcEndpoints.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of VpcEndpoints",
+      "default": false
+    },
+    "Xray": {
+      "type": "object",
+      "description": "Enable AWS X-Ray tracing.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "Xray.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Xray",
+      "default": false
+    },
+    "app-data.AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "app-data.AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "app-data.Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "app-data.IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AssumableCdRole": false
+      },
+      "properties": {
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "AssumableCdRole"
+      ]
+    },
+    "app-data.IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of app-data.IamForCicd",
+      "default": false
+    },
+    "app-data.IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "app-data.Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "app-data.S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "app-data.StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "app-data.Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "app-data.TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "app-data.Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "app-data.Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of app-data.Terragrunt",
+      "default": false
+    }
+  },
+  "required": [
+    "StackName",
+    "app-data.StackName"
+  ]
+}

--- a/cmd/pkg/testdata/bump-schema-version/input/json-schemas/load-balancing-alb-v4.0.0.schema.json
+++ b/cmd/pkg/testdata/bump-schema-version/input/json-schemas/load-balancing-alb-v4.0.0.schema.json
@@ -1,0 +1,219 @@
+{
+  "$id": "boilerplate/terraform/load-balancing-alb-load-balancing-alb-v3.4.0",
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "Dns": {
+      "type": "object",
+      "description": "If Enable is true, a Route 53 record will be created for the ALB. If EnableHttps is true, a certificate will be configured for the domain and the ALB will be configured to use it. All HTTP requests will be redirected to HTTPS.",
+      "default": {
+        "Enable": true,
+        "EnableHttps": true
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": true
+        },
+        "EnableHttps": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "required": [
+        "Enable",
+        "EnableHttps"
+      ]
+    },
+    "Dns.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Dns",
+      "default": true
+    },
+    "Dns.EnableHttps": {
+      "type": "boolean",
+      "description": "Override single parameter of Dns",
+      "default": true
+    },
+    "Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AssumableCdRole": false
+      },
+      "properties": {
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "AssumableCdRole"
+      ]
+    },
+    "IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of IamForCicd",
+      "default": false
+    },
+    "IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "Internal": {
+      "type": "boolean",
+      "description": "If true, the Application Load Balancer will be internal. If false, it will be internet-facing.",
+      "default": true
+    },
+    "Name": {
+      "type": "string",
+      "description": "Application Load Balancer name",
+      "default": "main"
+    },
+    "Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of Terragrunt",
+      "default": false
+    },
+    "load-balancing-alb-data.AccountId": {
+      "type": "string",
+      "description": "AWS account ID."
+    },
+    "load-balancing-alb-data.AwsProviderVersion": {
+      "type": "string",
+      "description": "The version of the AWS provider to use.",
+      "default": "5.81.0"
+    },
+    "load-balancing-alb-data.Environment": {
+      "type": "string",
+      "description": "Environment name."
+    },
+    "load-balancing-alb-data.IamForCicd": {
+      "type": "object",
+      "description": "Enable IAM roles for CI/CD.",
+      "default": {
+        "AssumableCdRole": false
+      },
+      "properties": {
+        "AssumableCdRole": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "AssumableCdRole"
+      ]
+    },
+    "load-balancing-alb-data.IamForCicd.AssumableCdRole": {
+      "type": "boolean",
+      "description": "Override single parameter of load-balancing-alb-data.IamForCicd",
+      "default": false
+    },
+    "load-balancing-alb-data.IncludeLockFile": {
+      "type": "boolean",
+      "description": "Include a Terraform lock file.",
+      "default": false
+    },
+    "load-balancing-alb-data.Region": {
+      "type": "string",
+      "description": "AWS region.",
+      "default": "eu-west-1"
+    },
+    "load-balancing-alb-data.S3Backend": {
+      "type": "boolean",
+      "description": "Use S3 as a backend.",
+      "default": true
+    },
+    "load-balancing-alb-data.StackName": {
+      "type": "string",
+      "description": "Name of Terraform stack."
+    },
+    "load-balancing-alb-data.Team": {
+      "type": "string",
+      "description": "Team name."
+    },
+    "load-balancing-alb-data.TerraformVersion": {
+      "type": "string",
+      "description": "The version of Terraform to use.",
+      "default": "\u003e= 1.7.0"
+    },
+    "load-balancing-alb-data.Terragrunt": {
+      "type": "object",
+      "description": "Enable Terragrunt.\nThis is a experimental feature and should not be used in production.",
+      "default": {
+        "Enable": false
+      },
+      "properties": {
+        "Enable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "Enable"
+      ]
+    },
+    "load-balancing-alb-data.Terragrunt.Enable": {
+      "type": "boolean",
+      "description": "Override single parameter of load-balancing-alb-data.Terragrunt",
+      "default": false
+    }
+  },
+  "required": [
+    "StackName",
+    "load-balancing-alb-data.StackName"
+  ]
+}

--- a/cmd/pkg/testdata/bump-schema-version/input/packages.yml
+++ b/cmd/pkg/testdata/bump-schema-version/input/packages.yml
@@ -1,0 +1,7 @@
+Packages:
+    - OutputFolder: app-hello
+      Template: app
+      Ref: app-v8.0.5
+      VarFiles:
+        - config/common-config.yml
+        - config/app-hello.yml

--- a/cmd/pkg/update.go
+++ b/cmd/pkg/update.go
@@ -11,12 +11,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewUpdateCommand(ghReleases GitHubReleases) *cobra.Command {
+func NewUpdateCommand(ghReleases GitHubReleases, schemaGenerator common.SchemaGenerator) *cobra.Command {
 	var flagDisableManifestUpdate bool
 	var flagUpdateCommandUpdateSchema bool
 	var flagMigrateConfig bool
 
-	updater := update.NewUpdater(ghReleases)
+	updater := update.NewUpdater(ghReleases, schemaGenerator)
 
 	cmd := &cobra.Command{
 		Use:   "update [outputFolder ...]",

--- a/cmd/pkg/update_test.go
+++ b/cmd/pkg/update_test.go
@@ -205,7 +205,8 @@ func NewSchemaGeneratorMock(jsonSchemasDir string) SchemaGeneratorMock {
 	}
 }
 
-// CreateJsonSchemaFile creates JSON schema file from a Boilerplate template configuration
+// CreateJsonSchemaFile emulates creating JSON schema file from a Boilerplate template configuration.
+// Instead of generating the schema, it just copies a pre-generated file.
 func (s SchemaGeneratorMock) CreateJsonSchemaFile(
 	ctx context.Context, manifestPackagePrefix string, pkg common.Package) ([]byte, error) {
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
+	"github.com/oslokommune/ok/pkg/pkg/schema"
 	"os"
 	"path"
 
@@ -58,12 +59,14 @@ func init() {
 
 	// Create dependencies
 	ghReleases := githubreleases.NewGitHubReleases()
-	updateCommand := pkg.NewUpdateCommand(ghReleases)
+	schemaGenerator := schema.NewGenerator()
+	addCommand := pkg.NewAddCommand(schemaGenerator)
+	updateCommand := pkg.NewUpdateCommand(ghReleases, schemaGenerator)
 
 	// Add commands
 	rootCmd.AddCommand(pkgCommand)
-	pkgCommand.AddCommand(pkg.AddCommand)
 	pkgCommand.AddCommand(pkg.InstallCommand)
+	pkgCommand.AddCommand(addCommand)
 	pkgCommand.AddCommand(updateCommand)
 	pkgCommand.AddCommand(pkg.FmtCommand)
 	pkgCommand.AddCommand(pkg.SchemaCommand)

--- a/pkg/pkg/common/package.go
+++ b/pkg/pkg/common/package.go
@@ -21,10 +21,10 @@ type Package struct {
 
 func (p Package) String() string {
 	outputFolder := fmt.Sprintf("%-*.*s", outputFolderWidth, outputFolderWidth, p.OutputFolder)
-	template := fmt.Sprintf("%-*.*s", templateWidth, templateWidth, p.Template)
+	ref := fmt.Sprintf("%-*.*s", templateWidth, templateWidth, p.Ref)
 	varFiles := fmt.Sprintf("%-*.*s", varFilesWidth, varFilesWidth, fmt.Sprint(p.VarFiles))
 
-	return fmt.Sprintf("%s %s %s", outputFolder, template, varFiles)
+	return fmt.Sprintf("%s %s %s", outputFolder, ref, varFiles)
 }
 
 // Key returns a unique key for the package

--- a/pkg/pkg/common/schema_generator.go
+++ b/pkg/pkg/common/schema_generator.go
@@ -1,0 +1,8 @@
+package common
+
+import "context"
+
+type SchemaGenerator interface {
+	CreateJsonSchemaFile(
+		ctx context.Context, manifestPackagePrefix string, pkg Package) ([]byte, error)
+}

--- a/pkg/pkg/update/update_test.go
+++ b/pkg/pkg/update/update_test.go
@@ -98,7 +98,7 @@ func TestUpdatedPackages(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			updatedManifest, err := updatePackages(tc.manifest, tc.packagesToUpdate, tc.latestReleases)
+			updatedManifest, _, err := updatePackages(tc.manifest, tc.packagesToUpdate, tc.latestReleases)
 
 			if tc.expectError {
 				require.Error(t, err)


### PR DESCRIPTION
# Description

When running `ok pkg update`, the json schema declaration gets set to the _current_ version of the template version. For instance, given current package version is 8.0.4, and new version is 9.0.0:

After running `ok pkg update`, the var file look like this:

```yaml
# yaml-language-server: $schema=.schemas/app-v8.0.4.schema.json
```

when it should look like this


```yaml
# yaml-language-server: $schema=.schemas/app-v9.0.0.schema.json
```

The important commit is this: https://github.com/oslokommune/ok/pull/375/commits/4693f571dd1e1af86b7b3b9caa28536e26b784a6

The rest are for fixing tests and refactorings.

## Fix

Make sure the function `updateSchemaConfiguration` gets the update packages, not the original ones. This fixes the bug because this function writes the json schema declaration to the var file.

# TL;DR

```
selectedPackages = updatedSelectedPackages
```

fixes a bug where old json schema version gets written to a var file.
