### PR TITLE
feat: add cli command for generating aws cli config

### DIFF
--- a/cmd/aws/generate.go
+++ b/cmd/aws/generate.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"github.com/oslokommune/ok/pkg/aws/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ssoStarturl string
+	ssoRegion   string
+	region      string
+	sessionName string
+	template    string
+)
+
+var ConfigGeneratorCommand = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate AWS CLI configuration for AWS IAM Identity Center roles",
+	Long: `Generate AWS CLI configuration for AWS IAM Identity Center roles.
+
+Profile name template supports the following variables:
+  {{.SessionName}}  - The name of the SSO session
+  {{.AccountName}}  - The name of the AWS account
+  {{.AccountID}}    - The ID of the AWS account
+  {{.RoleName}}     - The name of the IAM role
+
+Example:
+  ok aws generate \
+    --sso-start-url "https://my-sso.awsapps.com/start" \
+    --sso-region "eu-west-1" \
+    --template "ok-{{.AccountName}}-{{.RoleName}}"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if region == "" {
+			region = ssoRegion
+		}
+
+		return config.Generate(config.Options{
+			SsoStartUrl: ssoStarturl,
+			SsoRegion:   ssoRegion,
+			Region:      region,
+			SessionName: sessionName,
+			Template:    template,
+		})
+	},
+}
+
+func init() {
+	ConfigGeneratorCommand.Flags().StringVar(&ssoStarturl, "sso-start-url", "", "The start URL of the AWS IAM Identity Center instance")
+	ConfigGeneratorCommand.Flags().StringVar(&ssoRegion, "sso-region", "", "The region of the AWS IAM Identity Center instance")
+	ConfigGeneratorCommand.Flags().StringVar(&region, "region", "", "The default region for generated profiles (defaults to sso-region if not set)")
+	ConfigGeneratorCommand.Flags().StringVar(&sessionName, "session-name", "", "An optional name of the SSO session (defaults to the AWS IAM Identity Center instance identifier if not set)")
+	ConfigGeneratorCommand.Flags().StringVar(&template, "template", "", "Go string template for generating profile names")
+	ConfigGeneratorCommand.MarkFlagRequired("sso-start-url")
+	ConfigGeneratorCommand.MarkFlagRequired("sso-region")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ func init() {
 	rootCmd.AddCommand(awsCommand)
 	awsCommand.AddCommand(aws.EcsExecCommand)
 	awsCommand.AddCommand(aws.AdminSessionCommand)
+	awsCommand.AddCommand(aws.ConfigGeneratorCommand)
 
 	initializeConfiguration()
 }

--- a/pkg/aws/config/assets/callback_result.html
+++ b/pkg/aws/config/assets/callback_result.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ok-aws-config-generator</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background-color: #f8f9fa;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+    }
+    .container {
+      background-color: white;
+      padding: 2rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      text-align: center;
+      max-width: 400px;
+    }
+    .icon {
+      font-size: 48px;
+      margin-bottom: 1rem;
+    }
+    .success {
+      color: #28a745;
+    }
+    .error {
+      color: #dc3545;
+    }
+    h1 {
+      color: #212529;
+      margin-bottom: 1rem;
+      font-size: 1.5rem;
+    }
+    p {
+      color: #6c757d;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon {{.Class}}">{{.Icon}}</div>
+    <h1>{{.Message}}</h1>
+    <p>You can close this window and return to your terminal.</p>
+  </div>
+</body>
+</html>

--- a/pkg/aws/config/doc.go
+++ b/pkg/aws/config/doc.go
@@ -1,0 +1,17 @@
+// Package config provides AWS configuration management functionality, primarily focused on
+// AWS SSO (Single Sign-On) profile generation and authentication.
+//
+// The package handles:
+//   - AWS SSO authentication flow
+//   - Account and role discovery
+//   - AWS config file generation
+//   - Profile name customization through templates
+//
+// Example usage:
+//
+//	err := config.Generate(config.Options{
+//	    SsoStartUrl: "https://my-sso.awsapps.com/start",
+//	    SsoRegion:   "us-east-1",
+//	    Region:      "eu-west-1",
+//	})
+package config

--- a/pkg/aws/config/generate.go
+++ b/pkg/aws/config/generate.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sso"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+)
+
+const (
+	defaultProfileNameTemplate = "{{.SessionName}}-{{.AccountName}}-{{.RoleName}}"
+	awsConfigTemplate          = `; run 'ok aws generate' to update the configuration
+[sso-session {{.SessionName}}]
+sso_start_url = {{.StartURL}}
+sso_region = {{.SSORegion}}
+sso_registration_scopes = sso:account:access
+{{- range .Profiles}}
+
+[profile {{.Name}}]
+sso_session = {{$.SessionName}}
+sso_account_id = {{.AccountID}}
+sso_role_name = {{.RoleName}}
+region = {{$.ProfileRegion}}
+{{- end}}
+`
+)
+
+// NewConfigGenerator creates a new ConfigGenerator with the given options.
+// It validates required fields and sets default values where appropriate.
+func NewConfigGenerator(opts Options) (*ConfigGenerator, error) {
+	if opts.SsoStartUrl == "" {
+		return nil, fmt.Errorf("SSO start URL is required")
+	}
+	if opts.SsoRegion == "" {
+		return nil, fmt.Errorf("SSO region is required")
+	}
+
+	if opts.Region == "" {
+		opts.Region = opts.SsoRegion
+	}
+
+	if opts.SessionName == "" {
+		opts.SessionName = strings.Split(strings.TrimPrefix(opts.SsoStartUrl, "https://"), ".")[0]
+	}
+
+	ssooidcClient := ssooidc.New(ssooidc.Options{
+		Region: opts.SsoRegion,
+	})
+	//
+	ssoClient := sso.New(sso.Options{
+		Region: opts.SsoRegion,
+		// We configure retries to mitigate TooManyRequestsException when fetching accounts and roles
+		RetryMaxAttempts: 100,
+		RetryMode:        aws.RetryModeStandard,
+	})
+
+	return &ConfigGenerator{
+		ssooidcClient: ssooidcClient,
+		ssoClient:     ssoClient,
+		options:       opts,
+	}, nil
+}
+
+func (g *ConfigGenerator) Generate(ctx context.Context) error {
+	accounts, err := GetAccounts(ctx, g.ssoClient, g.ssooidcClient, g.options.SsoStartUrl, g.options.SsoRegion)
+	if err != nil {
+		return fmt.Errorf("getting accounts: %w", err)
+	}
+	if len(accounts) == 0 {
+		return fmt.Errorf("no accounts found")
+	}
+	profiles, err := g.generateProfiles(accounts)
+	if err != nil {
+		return fmt.Errorf("generating profiles: %w", err)
+	}
+
+	// Print summary header
+	fmt.Printf("\nGenerating AWS config for %d profiles\n", len(profiles))
+	fmt.Println("\nAWS CLI config (e.g., `$HOME/.aws/config`):")
+	fmt.Println("---")
+
+	config, err := g.generateConfig(profiles)
+	if err != nil {
+		return fmt.Errorf("generating config: %w", err)
+	}
+
+	fmt.Print(config)
+	fmt.Println("---")
+
+	return nil
+}
+
+func (g *ConfigGenerator) generateProfiles(accounts []Account) ([]Profile, error) {
+	var profiles []Profile
+	for _, account := range accounts {
+		for _, roleName := range account.Roles {
+			profileName, err := generateProfileName(profileNameData{
+				SessionName: g.options.SessionName,
+				AccountName: account.Name,
+				AccountID:   account.ID,
+				RoleName:    roleName,
+			}, g.options.Template)
+			if err != nil {
+				return nil, fmt.Errorf("generating profile name for account %s role %s: %w",
+					account.Name, roleName, err)
+			}
+
+			profiles = append(profiles, Profile{
+				Name:        profileName,
+				AccountID:   account.ID,
+				RoleName:    roleName,
+				AccountName: account.Name,
+			})
+		}
+	}
+	return profiles, nil
+}
+
+func (g *ConfigGenerator) generateConfig(profiles []Profile) (string, error) {
+	data := profileConfigData{
+		SessionName:   g.options.SessionName,
+		StartURL:      g.options.SsoStartUrl,
+		SSORegion:     g.options.SsoRegion,
+		ProfileRegion: g.options.Region,
+		Profiles:      profiles,
+	}
+
+	tmpl, err := template.New("config").Parse(awsConfigTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parsing config template: %w", err)
+	}
+
+	var buf strings.Builder
+	err = tmpl.Execute(&buf, data)
+	if err != nil {
+		return "", fmt.Errorf("executing config template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// sanitizeName converts a string into an opinionated profile name by applying
+// consistent formatting rules and removing invalid characters.
+func sanitizeName(input string) string {
+	sep := "-"
+	// Split on acronym boundaries
+	reg := regexp.MustCompile(`([A-Z]+)([A-Z][a-z])`)
+	result := reg.ReplaceAllString(input, "${1}"+sep+"${2}")
+
+	// Split on word boundaries
+	reg = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	result = reg.ReplaceAllString(result, "${1}"+sep+"${2}")
+
+	// Convert to lowercase
+	result = strings.ToLower(result)
+
+	// Replace non-alphanumeric chars with separator
+	reg = regexp.MustCompile(`[^a-z0-9]+`)
+	result = reg.ReplaceAllString(result, sep)
+
+	// Trim hyphens from start/end
+	return strings.Trim(result, sep)
+}
+
+func generateProfileName(data profileNameData, templateStr string) (string, error) {
+	if templateStr == "" {
+		templateStr = defaultProfileNameTemplate
+	}
+
+	tmpl, err := template.New("profile-name").Parse(templateStr)
+	if err != nil {
+		return "", fmt.Errorf("parsing profile name template: %w", err)
+	}
+
+	var result strings.Builder
+	err = tmpl.Execute(&result, data)
+	if err != nil {
+		return "", fmt.Errorf("executing profile name template: %w", err)
+	}
+
+	return sanitizeName(result.String()), nil
+}
+
+// Generate creates AWS SSO profile configurations based on the provided options.
+// It handles the SSO authentication flow and generates AWS config file content.
+func Generate(opts Options) error {
+	generator, err := NewConfigGenerator(opts)
+	if err != nil {
+		return fmt.Errorf("creating config generator: %w", err)
+	}
+	return generator.Generate(context.Background())
+}

--- a/pkg/aws/config/generate_test.go
+++ b/pkg/aws/config/generate_test.go
@@ -1,0 +1,233 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple case",
+			input:    "HelloWorld",
+			expected: "hello-world",
+		},
+		{
+			name:     "multiple words with acronym",
+			input:    "MyAWSRole",
+			expected: "my-aws-role",
+		},
+		{
+			name:     "special characters",
+			input:    "*Hello@_World_foo_",
+			expected: "hello-world-foo",
+		},
+		{
+			name:     "multiple acronyms",
+			input:    "AWSIAMRole",
+			expected: "awsiam-role",
+		},
+		{
+			name:     "consecutive capitals",
+			input:    "MyABCRole",
+			expected: "my-abc-role",
+		},
+		{
+			name:     "number followed by word",
+			input:    "hello2World",
+			expected: "hello2-world",
+		},
+		{
+			name:     "preserve existing hyphens",
+			input:    "example-dev",
+			expected: "example-dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeName(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []Profile
+		options  Options
+		want     string
+	}{
+		{
+			name: "single profile",
+			profiles: []Profile{
+				{
+					Name:        "dev-admin",
+					AccountID:   "123456789012",
+					RoleName:    "AdminRole",
+					AccountName: "dev",
+				},
+			},
+			options: Options{
+				SessionName: "mysession",
+				SsoStartUrl: "https://my-start-url.awsapps.com/start",
+				SsoRegion:   "us-east-1",
+				Region:      "eu-west-1",
+			},
+			want: `; run 'ok aws generate' to update the configuration
+[sso-session mysession]
+sso_start_url = https://my-start-url.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[profile dev-admin]
+sso_session = mysession
+sso_account_id = 123456789012
+sso_role_name = AdminRole
+region = eu-west-1
+`,
+		},
+		{
+			name: "multiple profiles",
+			profiles: []Profile{
+				{
+					Name:        "dev-admin",
+					AccountID:   "123456789012",
+					RoleName:    "AdminRole",
+					AccountName: "dev",
+				},
+				{
+					Name:        "prod-read",
+					AccountID:   "987654321098",
+					RoleName:    "ReadOnlyRole",
+					AccountName: "prod",
+				},
+			},
+			options: Options{
+				SessionName: "mysession",
+				SsoStartUrl: "https://my-start-url.awsapps.com/start",
+				SsoRegion:   "us-east-1",
+			},
+			want: `; run 'ok aws generate' to update the configuration
+[sso-session mysession]
+sso_start_url = https://my-start-url.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[profile dev-admin]
+sso_session = mysession
+sso_account_id = 123456789012
+sso_role_name = AdminRole
+region = us-east-1
+
+[profile prod-read]
+sso_session = mysession
+sso_account_id = 987654321098
+sso_role_name = ReadOnlyRole
+region = us-east-1
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a generator with test options
+			generator, err := NewConfigGenerator(tt.options)
+			if err != nil {
+				t.Fatalf("NewConfigGenerator() error = %v", err)
+			}
+
+			got, err := generator.generateConfig(tt.profiles)
+			if err != nil {
+				t.Fatalf("generateConfig() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("generateConfig() output mismatch:\ngot:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateProfileName(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         profileNameData
+		template     string
+		expected     string
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name: "default template",
+			data: profileNameData{
+				SessionName: "MySession",
+				AccountName: "my-account",
+				AccountID:   "123456789012",
+				RoleName:    "AdminRole",
+			},
+			template: "",
+			expected: "my-session-my-account-admin-role",
+		},
+		{
+			name: "custom template with role mapping",
+			data: profileNameData{
+				SessionName: "mysso",
+				AccountName: "my-account",
+				AccountID:   "123456789012",
+				RoleName:    "AdminRole",
+			},
+			template: "{{.AccountName}}-{{if eq .RoleName \"AdminRole\"}}MyAdminRole{{else}}{{.RoleName}}{{end}}",
+			expected: "my-account-my-admin-role",
+		},
+		{
+			name: "template with account ID",
+			data: profileNameData{
+				SessionName: "mysso",
+				AccountName: "MyAccount",
+				AccountID:   "123456789012",
+				RoleName:    "ReadRole",
+			},
+			template: "{{.AccountID}}-{{.RoleName}}",
+			expected: "123456789012-read-role",
+		},
+		{
+			name: "invalid template",
+			data: profileNameData{
+				SessionName: "mysso",
+				AccountName: "MyAccount",
+				AccountID:   "123456789012",
+				RoleName:    "ReadRole",
+			},
+			template:    "{{.InvalidField}}",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateProfileName(tt.data, tt.template)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if got != tt.expected {
+				t.Errorf("generateProfileName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/aws/config/sso.go
+++ b/pkg/aws/config/sso.go
@@ -1,0 +1,345 @@
+package config
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sso"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+)
+
+const (
+	timeout    = 3 * time.Minute
+	clientName = "ok-aws-config-generator"
+	pkceLength = 64
+)
+
+//go:embed assets/callback_result.html
+var resultHTML string
+
+// callbackServer manages the local HTTP server used during the OAuth2 authentication flow.
+type callbackServer struct {
+	server *http.Server
+	code   chan string
+	state  string
+}
+
+// GetAccounts retrieves all accessible AWS accounts and their roles through SSO.
+// It handles the browser-based authentication flow and token management.
+func GetAccounts(ctx context.Context, ssoClient *sso.Client, ssooidcClient *ssooidc.Client, startUrl, region string) ([]Account, error) {
+	server, err := startCallbackServer()
+	if err != nil {
+		return nil, fmt.Errorf("starting callback server: %w", err)
+	}
+	defer server.close()
+
+	token, err := authorize(ctx, ssooidcClient, server, startUrl, region)
+	if err != nil {
+		return nil, err
+	}
+
+	return listAccounts(ctx, ssoClient, *token.AccessToken)
+}
+
+func startCallbackServer() (*callbackServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("creating listener: %w", err)
+	}
+
+	state, err := generateState()
+	if err != nil {
+		listener.Close()
+		return nil, fmt.Errorf("generating state: %w", err)
+	}
+
+	code := make(chan string, 1)
+	server := &callbackServer{
+		code:  code,
+		state: state,
+	}
+
+	mux := http.NewServeMux()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+
+		tmpl := template.Must(template.New("result").Parse(resultHTML))
+		data := struct {
+			Class   string
+			Icon    string
+			Message string
+		}{}
+
+		if gotState := r.URL.Query().Get("state"); gotState != state {
+			w.WriteHeader(http.StatusBadRequest)
+			data.Class = "error"
+			data.Icon = "✕"
+			data.Message = "Authorization error"
+			if err := tmpl.Execute(w, data); err != nil {
+			}
+			w.(http.Flusher).Flush()
+			code <- ""
+			server.close()
+			return
+		}
+
+		authCode := r.URL.Query().Get("code")
+		if authCode == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			data.Class = "error"
+			data.Icon = "✕"
+			data.Message = "Authorization error"
+			if err := tmpl.Execute(w, data); err != nil {
+			}
+			w.(http.Flusher).Flush()
+			code <- ""
+			server.close()
+			return
+		}
+
+		data.Class = "success"
+		data.Icon = "✓"
+		data.Message = "Authorization success"
+		if err := tmpl.Execute(w, data); err != nil {
+		}
+		w.(http.Flusher).Flush()
+		code <- authCode
+		server.close()
+	}
+
+	mux.HandleFunc("/", handler)
+
+	server.server = &http.Server{
+		Handler: mux,
+		Addr:    listener.Addr().String(),
+	}
+
+	// Add this line to print the callback URL
+	fmt.Printf("Started local callback server at: http://%s\n", server.server.Addr)
+
+	go server.server.Serve(listener)
+
+	return server, nil
+}
+
+func (s *callbackServer) waitForCode(ctx context.Context) (string, error) {
+	select {
+	case code := <-s.code:
+		if code == "" {
+			return "", fmt.Errorf("authorization failed or was denied")
+		}
+		return code, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (s *callbackServer) close() error {
+	if err := s.server.Close(); err != nil {
+		return fmt.Errorf("closing server: %w", err)
+	}
+	return nil
+}
+
+func (s *callbackServer) getCallbackURL() string {
+	return fmt.Sprintf("http://%s", s.server.Addr)
+}
+
+// generateState creates a random 16-byte state parameter for OAuth2 CSRF protection.
+// The state is hex-encoded to make it URL-safe.
+// Returns the hex-encoded state string and any error encountered.
+func generateState() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// generateCodeVerifier creates a random code verifier string for PKCE (Proof Key for Code Exchange).
+// The verifier is a random string of length pkceLength using characters from the allowed charset.
+// The charset follows RFC 7636 requirements: characters from A-Z, a-z, 0-9, and "-._~".
+// Returns the code verifier string and any error encountered.
+func generateCodeVerifier() (string, error) {
+	const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+
+	b := make([]byte, pkceLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random bytes: %w", err)
+	}
+
+	result := make([]byte, pkceLength)
+	for i := range b {
+		result[i] = charset[int(b[i])%len(charset)]
+	}
+	return string(result), nil
+}
+
+// generateCodeChallenge creates a code challenge from a code verifier for PKCE.
+// The challenge is created by:
+// 1. Taking the SHA256 hash of the verifier
+// 2. Base64URL-encoding the hash (without padding)
+// This follows the S256 transformation method specified in RFC 7636.
+func generateCodeChallenge(verifier string) (string, error) {
+	if len(verifier) < 43 || len(verifier) > 128 {
+		return "", fmt.Errorf("code verifier length must be between 43 and 128 characters")
+	}
+	hash := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
+}
+
+func openURL(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}
+
+// authorize performs the OAuth2 authorization flow with AWS SSO.
+// It opens the user's browser for authentication and waits for the callback.
+func authorize(ctx context.Context, ssooidcClient *ssooidc.Client, server *callbackServer, startUrl, region string) (*ssooidc.CreateTokenOutput, error) {
+	clientCreds, err := registerClient(ctx, ssooidcClient, server.getCallbackURL(), startUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier, err := generateCodeVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("generating code verifier: %w", err)
+	}
+	challenge, err := generateCodeChallenge(verifier)
+	if err != nil {
+		return nil, fmt.Errorf("generating code challenge: %w", err)
+	}
+
+	authURL := fmt.Sprintf(
+		"https://oidc.%s.amazonaws.com/authorize?%s",
+		region,
+		url.Values{
+			"client_id":             {*clientCreds.ClientId},
+			"response_type":         {"code"},
+			"redirect_uri":          {server.getCallbackURL()},
+			"code_challenge":        {challenge},
+			"code_challenge_method": {"S256"},
+			"scope":                 {"sso:account:access"},
+			"state":                 {server.state},
+		}.Encode(),
+	)
+
+	fmt.Println("\nWaiting for browser authorization")
+	if err := openURL(authURL); err != nil {
+		fmt.Printf("\nPlease open this URL in your browser:\n%s\n", authURL)
+	}
+
+	authCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	code, err := server.waitForCode(authCtx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for authorization code: %w", err)
+	}
+
+	return createToken(ctx, ssooidcClient, clientCreds, code, server.getCallbackURL(), verifier)
+}
+
+func registerClient(ctx context.Context, client *ssooidc.Client, callbackURL, startUrl string) (*ssooidc.RegisterClientOutput, error) {
+	return client.RegisterClient(ctx, &ssooidc.RegisterClientInput{
+		ClientName:   aws.String(clientName),
+		ClientType:   aws.String("public"),
+		Scopes:       []string{"sso:account:access"},
+		GrantTypes:   []string{"authorization_code", "refresh_token"},
+		IssuerUrl:    aws.String(startUrl),
+		RedirectUris: []string{callbackURL},
+	})
+}
+
+func createToken(ctx context.Context, client *ssooidc.Client, clientCreds *ssooidc.RegisterClientOutput, code, callbackURL, verifier string) (*ssooidc.CreateTokenOutput, error) {
+	return client.CreateToken(ctx, &ssooidc.CreateTokenInput{
+		ClientId:     clientCreds.ClientId,
+		ClientSecret: clientCreds.ClientSecret,
+		GrantType:    aws.String("authorization_code"),
+		Code:         aws.String(code),
+		RedirectUri:  aws.String(callbackURL),
+		CodeVerifier: aws.String(verifier),
+	})
+}
+
+// listAccounts retrieves all AWS accounts accessible to the authenticated user.
+// For each account, it also fetches the available IAM roles.
+func listAccounts(ctx context.Context, ssoClient *sso.Client, accessToken string) ([]Account, error) {
+	var accounts []Account
+	paginator := sso.NewListAccountsPaginator(ssoClient, &sso.ListAccountsInput{
+		AccessToken: &accessToken,
+	})
+
+	fmt.Print("\nFetching available accounts and roles")
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing accounts: %w", err)
+		}
+
+		for _, acc := range page.AccountList {
+			account := Account{
+				ID:   *acc.AccountId,
+				Name: *acc.AccountName,
+			}
+
+			roles, err := listAccountRoles(ctx, ssoClient, accessToken, *acc.AccountId)
+			if err != nil {
+				return nil, fmt.Errorf("listing roles for account %s: %w", *acc.AccountId, err)
+			}
+			account.Roles = roles
+
+			accounts = append(accounts, account)
+			fmt.Print(".")
+		}
+	}
+	fmt.Println()
+
+	return accounts, nil
+}
+
+func listAccountRoles(ctx context.Context, ssoClient *sso.Client, accessToken string, accountID string) ([]string, error) {
+	var roles []string
+	paginator := sso.NewListAccountRolesPaginator(ssoClient, &sso.ListAccountRolesInput{
+		AccessToken: &accessToken,
+		AccountId:   &accountID,
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing roles: %w", err)
+		}
+
+		for _, role := range page.RoleList {
+			roles = append(roles, *role.RoleName)
+		}
+	}
+
+	return roles, nil
+}

--- a/pkg/aws/config/types.go
+++ b/pkg/aws/config/types.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/sso"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+)
+
+// Options configures the AWS SSO config generation
+type Options struct {
+	SsoStartUrl string
+	SsoRegion   string
+	Region      string
+	SessionName string
+	Template    string
+}
+
+// Account represents an AWS SSO account
+type Account struct {
+	ID    string
+	Name  string
+	Roles []string
+}
+
+// Profile represents an AWS SSO profile configuration
+type Profile struct {
+	Name        string
+	AccountID   string
+	RoleName    string
+	AccountName string
+}
+
+// profileNameData contains data for profile name generation
+type profileNameData struct {
+	SessionName string
+	AccountName string
+	AccountID   string
+	RoleName    string
+}
+
+// profileConfigData contains data for profile config generation
+type profileConfigData struct {
+	SessionName   string
+	StartURL      string
+	SSORegion     string
+	ProfileRegion string
+	Profiles      []Profile
+}
+
+// ConfigGenerator handles AWS SSO configuration generation
+type ConfigGenerator struct {
+	ssooidcClient *ssooidc.Client
+	ssoClient     *sso.Client
+	options       Options
+}


### PR DESCRIPTION
Proposal for a new command in okcli that allows a user to generate AWS CLI configuration for all accounts and roles they have access to through AWS IAM Identity Center.

Example usage: `ok aws generate --sso-start-url "https://example.awsapps.com/start" --sso-region "us-east-1"`