### PR TITLE
fix: output diagnostics to standard error

### DIFF
--- a/pkg/aws/config/generate.go
+++ b/pkg/aws/config/generate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"text/template"
@@ -14,7 +15,7 @@ import (
 
 const (
 	defaultProfileNameTemplate = "{{.SessionName}}-{{.AccountName}}-{{.RoleName}}"
-	awsConfigTemplate          = `; run 'ok aws generate' to update the configuration
+	awsConfigTemplate          = `; Config starts here. Run 'ok aws generate' to generate new configuration.
 [sso-session {{.SessionName}}]
 sso_start_url = {{.StartURL}}
 sso_region = {{.SSORegion}}
@@ -79,10 +80,7 @@ func (g *ConfigGenerator) Generate(ctx context.Context) error {
 		return fmt.Errorf("generating profiles: %w", err)
 	}
 
-	// Print summary header
-	fmt.Printf("\nGenerating AWS config for %d profiles\n", len(profiles))
-	fmt.Println("\nAWS CLI config (e.g., `$HOME/.aws/config`):")
-	fmt.Println("---")
+	fmt.Fprintf(os.Stderr, "\nGenerating AWS CLI configuration (i.e., $HOME/.aws/config) for %d profiles\n\n", len(profiles))
 
 	config, err := g.generateConfig(profiles)
 	if err != nil {
@@ -90,7 +88,6 @@ func (g *ConfigGenerator) Generate(ctx context.Context) error {
 	}
 
 	fmt.Print(config)
-	fmt.Println("---")
 
 	return nil
 }

--- a/pkg/aws/config/generate_test.go
+++ b/pkg/aws/config/generate_test.go
@@ -80,7 +80,7 @@ func TestGenerateConfig(t *testing.T) {
 				SsoRegion:   "us-east-1",
 				Region:      "eu-west-1",
 			},
-			want: `; run 'ok aws generate' to update the configuration
+			want: `; Config starts here. Run 'ok aws generate' to generate new configuration.
 [sso-session mysession]
 sso_start_url = https://my-start-url.awsapps.com/start
 sso_region = us-east-1
@@ -114,7 +114,7 @@ region = eu-west-1
 				SsoStartUrl: "https://my-start-url.awsapps.com/start",
 				SsoRegion:   "us-east-1",
 			},
-			want: `; run 'ok aws generate' to update the configuration
+			want: `; Config starts here. Run 'ok aws generate' to generate new configuration.
 [sso-session mysession]
 sso_start_url = https://my-start-url.awsapps.com/start
 sso_region = us-east-1

--- a/pkg/aws/config/sso.go
+++ b/pkg/aws/config/sso.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"text/template"
@@ -127,8 +128,7 @@ func startCallbackServer() (*callbackServer, error) {
 		Addr:    listener.Addr().String(),
 	}
 
-	// Add this line to print the callback URL
-	fmt.Printf("Started local callback server at: http://%s\n", server.server.Addr)
+	fmt.Fprintf(os.Stderr, "Started local callback server at: http://%s\n", server.server.Addr)
 
 	go server.server.Serve(listener)
 
@@ -249,10 +249,11 @@ func authorize(ctx context.Context, ssooidcClient *ssooidc.Client, server *callb
 		}.Encode(),
 	)
 
-	fmt.Println("\nWaiting for browser authorization")
+	fmt.Fprintf(os.Stderr, "\nOpening browser at URL: %s\n", authURL)
 	if err := openURL(authURL); err != nil {
-		fmt.Printf("\nPlease open this URL in your browser:\n%s\n", authURL)
+		fmt.Fprintf(os.Stderr, "\nFailed to open browser. Please open the URL manually.\n")
 	}
+	fmt.Fprintf(os.Stderr, "\nWaiting for browser authorization\n")
 
 	authCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -295,7 +296,7 @@ func listAccounts(ctx context.Context, ssoClient *sso.Client, accessToken string
 		AccessToken: &accessToken,
 	})
 
-	fmt.Print("\nFetching available accounts and roles")
+	fmt.Fprintf(os.Stderr, "\nFetching available accounts and roles")
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
@@ -315,10 +316,10 @@ func listAccounts(ctx context.Context, ssoClient *sso.Client, accessToken string
 			account.Roles = roles
 
 			accounts = append(accounts, account)
-			fmt.Print(".")
+			fmt.Fprintf(os.Stderr, ".")
 		}
 	}
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 
 	return accounts, nil
 }


### PR DESCRIPTION
This allows users of the CLI to more easily redirect the AWS CLI config to a file.