### PR TITLE
feat: Add `--recursive` for `ok pkg update`

### DIFF
--- a/cmd/pkg/install.go
+++ b/cmd/pkg/install.go
@@ -70,7 +70,7 @@ func installWithBanner(manifestPath string, manifestDir string, style lipgloss.S
 
 	err := installFromManifest(manifestPath, []string{}, manifestDir)
 	if err != nil {
-		return fmt.Errorf("installing from manifest %s: %w", manifestPath, err)
+		return fmt.Errorf("installing manifest %s: %w", manifestPath, err)
 	}
 
 	return nil

--- a/cmd/pkg/install.go
+++ b/cmd/pkg/install.go
@@ -51,13 +51,6 @@ BASE_URL=../boilerplate/terraform ok pkg install networking my-app
 	cmd.Flags().BoolVarP(&flagInteractive,
 		FlagInteractiveName, FlagInteractiveShorthand, false, FlagInteractiveUsage)
 
-	//cmd.Flags().BoolVarP(&flagRecursive,
-	//	"recursive",
-	//	"r",
-	//	false,
-	//	"Install packages from manifests found in all subdirectories, but excluding the current directory.",
-	//)
-
 	addRecursiveFlagToCmd(cmd, &flagRecursive, "Install")
 
 	return cmd

--- a/cmd/pkg/recursive.go
+++ b/cmd/pkg/recursive.go
@@ -1,0 +1,84 @@
+package pkg
+
+import (
+	"fmt"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/oslokommune/ok/pkg/pkg/common"
+	"github.com/spf13/cobra"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type RunRecursive func(manifestPath string, manifestDir string, style lipgloss.Style) error
+
+func runRecursiveInSubdirs(f RunRecursive) error {
+	var manifestPaths []string
+
+	err := filepath.Walk(".", func(path string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if path == "." {
+			return nil
+		}
+
+		if !fileInfo.IsDir() {
+			return nil
+		}
+
+		if strings.HasPrefix(fileInfo.Name(), ".") {
+			return filepath.SkipDir
+		}
+
+		// Is there a package manifest in this directory?
+		manifestPath := filepath.Join(path, common.PackagesManifestFilename)
+
+		_, err = os.Stat(manifestPath)
+		if err != nil {
+			return nil
+		}
+
+		manifestPaths = append(manifestPaths, manifestPath)
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("walking the path: %w", err)
+	}
+
+	for _, manifestPath := range manifestPaths {
+		manifestDir := path.Dir(manifestPath)
+
+		var style = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#00FF00")).
+			Background(lipgloss.Color("22")).
+			PaddingTop(2).
+			PaddingBottom(2).
+			PaddingLeft(4).
+			PaddingRight(4).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#FFFFFF"))
+
+		err = f(manifestPath, manifestDir, style)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func addRecursiveFlagToCmd(cmd *cobra.Command, flag *bool, commandName string) {
+	cmd.Flags().BoolVarP(flag,
+		"recursive",
+		"r",
+		false,
+		fmt.Sprintf("%s packages from manifests found in all subdirectories, but excluding the current directory.", commandName),
+	)
+}

--- a/cmd/pkg/testdata/update/recursive/expected/app-common/config.yml
+++ b/cmd/pkg/testdata/update/recursive/expected/app-common/config.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/app-common-v4.0.0.schema.json
+StackName: "app-common"
+
+Terragrunt:
+  Enable: true
+
+IncludeLockFile: false

--- a/cmd/pkg/testdata/update/recursive/expected/app-common/packages.yml
+++ b/cmd/pkg/testdata/update/recursive/expected/app-common/packages.yml
@@ -1,0 +1,7 @@
+Packages:
+    - OutputFolder: app-common
+      Template: app-common
+      Ref: app-common-v4.0.0
+      VarFiles:
+        - ../common-config.yml
+        - config.yml

--- a/cmd/pkg/testdata/update/recursive/expected/app-hello/config.yml
+++ b/cmd/pkg/testdata/update/recursive/expected/app-hello/config.yml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/app-v9.0.0.schema.json
+StackName: "app-hello"
+app-data.StackName: "app-hello-data"
+AppName: "hello"
+AppEcsExec: true
+AppReadOnlyRootFileSystem: true
+ExampleImage:
+  Enable: true
+ServiceConnect:
+  Enable: true
+AlbHostRouting:
+  Enable: true
+  Internal: false
+  Subdomain:
+    Enable: true
+    TargetGroupTargetStickiness: false
+  ApexDomain:
+    Enable: false
+    TargetGroupTargetStickiness: false
+DatabaseConnectivity:
+  Enable: true
+OpenTelemetrySidecar:
+  Enable: true
+VpcEndpoints:
+  Enable: true
+Xray:
+  Enable: true
+DailyShutdown:
+  Enable: true
+IamForCicd:
+  Enable: true
+  AppGitHubRepo: pirates-apps
+  IacGitHubRepo: pirates-iac
+  AssumableCdRole: false

--- a/cmd/pkg/testdata/update/recursive/expected/app-hello/packages.yml
+++ b/cmd/pkg/testdata/update/recursive/expected/app-hello/packages.yml
@@ -1,0 +1,7 @@
+Packages:
+    - OutputFolder: app-hello
+      Template: app
+      Ref: app-v9.0.0
+      VarFiles:
+        - ../common-config.yml
+        - config.yml

--- a/cmd/pkg/testdata/update/recursive/expected/common-config.yml
+++ b/cmd/pkg/testdata/update/recursive/expected/common-config.yml
@@ -1,0 +1,4 @@
+AccountId: "123456789012"
+Region: "eu-west-1"
+Team: "kjoremiljo"
+Environment: "test-dev"

--- a/cmd/pkg/testdata/update/recursive/input/root/app-common/config.yml
+++ b/cmd/pkg/testdata/update/recursive/input/root/app-common/config.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/app-common-v3.6.0.schema.json
+StackName: "app-common"
+
+Terragrunt:
+  Enable: true
+
+IncludeLockFile: false

--- a/cmd/pkg/testdata/update/recursive/input/root/app-common/packages.yml
+++ b/cmd/pkg/testdata/update/recursive/input/root/app-common/packages.yml
@@ -1,0 +1,7 @@
+Packages:
+    - OutputFolder: app-common
+      Template: app-common
+      Ref: app-common-v3.6.0
+      VarFiles:
+        - ../common-config.yml
+        - config.yml

--- a/cmd/pkg/testdata/update/recursive/input/root/app-hello/config.yml
+++ b/cmd/pkg/testdata/update/recursive/input/root/app-hello/config.yml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/app-v8.0.5.schema.json
+StackName: "app-hello"
+app-data.StackName: "app-hello-data"
+AppName: "hello"
+AppEcsExec: true
+AppReadOnlyRootFileSystem: true
+ExampleImage:
+  Enable: true
+ServiceConnect:
+  Enable: true
+AlbHostRouting:
+  Enable: true
+  Internal: false
+  Subdomain:
+    Enable: true
+    TargetGroupTargetStickiness: false
+  ApexDomain:
+    Enable: false
+    TargetGroupTargetStickiness: false
+DatabaseConnectivity:
+  Enable: true
+OpenTelemetrySidecar:
+  Enable: true
+VpcEndpoints:
+  Enable: true
+Xray:
+  Enable: true
+DailyShutdown:
+  Enable: true
+IamForCicd:
+  Enable: true
+  AppGitHubRepo: pirates-apps
+  IacGitHubRepo: pirates-iac
+  AssumableCdRole: false

--- a/cmd/pkg/testdata/update/recursive/input/root/app-hello/packages.yml
+++ b/cmd/pkg/testdata/update/recursive/input/root/app-hello/packages.yml
@@ -1,0 +1,7 @@
+Packages:
+    - OutputFolder: app-hello
+      Template: app
+      Ref: app-v8.0.5
+      VarFiles:
+        - ../common-config.yml
+        - config.yml

--- a/cmd/pkg/testdata/update/recursive/input/root/common-config.yml
+++ b/cmd/pkg/testdata/update/recursive/input/root/common-config.yml
@@ -1,0 +1,4 @@
+AccountId: "123456789012"
+Region: "eu-west-1"
+Team: "kjoremiljo"
+Environment: "test-dev"

--- a/cmd/pkg/update.go
+++ b/cmd/pkg/update.go
@@ -90,7 +90,7 @@ func createUpdateRecursiveFn(updater update.Updater, opts update.Options) RunRec
 
 		err := updateFromManifest(manifestDir, manifestPath, []string{}, updater, opts)
 		if err != nil {
-			return fmt.Errorf("installing from manifest %s: %w", manifestPath, err)
+			return fmt.Errorf("updating manifest %s: %w", manifestPath, err)
 		}
 
 		return nil

--- a/cmd/pkg/update.go
+++ b/cmd/pkg/update.go
@@ -52,7 +52,7 @@ ok pkg update my-package
 			if flagRecursive {
 				return runRecursiveInSubdirs(createUpdateRecursiveFn(updater, opts))
 			} else {
-				return updateFromManifest(common.PackagesManifestFilename, outputFolders, ".", updater, opts)
+				return updateFromManifest(".", common.PackagesManifestFilename, outputFolders, updater, opts)
 			}
 
 		},
@@ -88,7 +88,7 @@ func createUpdateRecursiveFn(updater update.Updater, opts update.Options) RunRec
 		fmt.Println(style.Render(fmt.Sprintf("Updating package manifest: %s", manifestPath)))
 		fmt.Println()
 
-		err := updateFromManifest(manifestPath, []string{}, manifestDir, updater, opts)
+		err := updateFromManifest(manifestDir, manifestPath, []string{}, updater, opts)
 		if err != nil {
 			return fmt.Errorf("installing from manifest %s: %w", manifestPath, err)
 		}
@@ -97,8 +97,7 @@ func createUpdateRecursiveFn(updater update.Updater, opts update.Options) RunRec
 	}
 }
 
-// TODO remove workingDirectpry?
-func updateFromManifest(manifestFile string, outputFolders []string, workingDirectory string, updater update.Updater, opts update.Options) error {
+func updateFromManifest(workingDirectory string, manifestFile string, outputFolders []string, updater update.Updater, opts update.Options) error {
 	var packages []common.Package
 	var err error
 

--- a/cmd/pkg/update_test.go
+++ b/cmd/pkg/update_test.go
@@ -78,8 +78,7 @@ func TestUpdateCommand(t *testing.T) {
 				},
 			},
 			releases: map[string]string{
-				"app":        "v9.0.0",
-				"app-common": "v4.0.0",
+				"app": "v9.0.1",
 			},
 		},
 		{

--- a/cmd/pkg/update_test.go
+++ b/cmd/pkg/update_test.go
@@ -78,7 +78,26 @@ func TestUpdateCommand(t *testing.T) {
 				},
 			},
 			releases: map[string]string{
-				"app": "v9.0.1",
+				"app":        "v9.0.0",
+				"app-common": "v4.0.0",
+			},
+		},
+		{
+			TestData: TestData{
+				name:            "Should update ok packages recursively",
+				args:            []string{"--recursive"},
+				testdataRootDir: "testdata/update/recursive",
+				expectError:     false,
+				expectedFiles: []string{
+					"app-common/packages.yml",
+					"app-common/config.yml",
+					"app-hello/packages.yml",
+					"app-hello/config.yml",
+				},
+			},
+			releases: map[string]string{
+				"app":        "v9.0.0",
+				"app-common": "v4.0.0",
 			},
 		},
 	}

--- a/pkg/pkg/update/migrate_config/migrate.go
+++ b/pkg/pkg/update/migrate_config/migrate.go
@@ -10,11 +10,14 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path"
 )
 
-func MigrateVarFile(packagesToUpdate []common.Package) error {
+func MigrateVarFile(packagesToUpdate []common.Package, workingDirectory string) error {
 	for _, pkg := range packagesToUpdate {
-		for _, varFile := range pkg.VarFiles {
+		for _, varFileRelative := range pkg.VarFiles {
+			varFile := path.Join(workingDirectory, varFileRelative)
+
 			fileHash, err := getFileHash(varFile)
 			if err != nil {
 				return fmt.Errorf("getting file hash: %w", err)

--- a/pkg/pkg/update/update.go
+++ b/pkg/pkg/update/update.go
@@ -1,7 +1,6 @@
 package update
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"github.com/Masterminds/semver"
@@ -9,6 +8,7 @@ import (
 	"github.com/oslokommune/ok/pkg/pkg/update/migrate_config"
 	"github.com/oslokommune/ok/pkg/pkg/update/migrate_config/metadata"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
@@ -30,7 +30,7 @@ func NewUpdater(ghReleases GitHubReleases) Updater {
 }
 
 // Run updates the package manifest with the latest releases.
-func (u Updater) Run(pkgManifestFilename string, selectedPackagesInput []common.Package, opts Options) error {
+func (u Updater) Run(pkgManifestFilename string, selectedPackagesInput []common.Package, opts Options, workingDirectory string) error {
 	var selectedPackages []common.Package
 	var manifest common.PackageManifest
 	{
@@ -59,14 +59,14 @@ func (u Updater) Run(pkgManifestFilename string, selectedPackagesInput []common.
 	}
 
 	if opts.UpdateSchema {
-		err := u.updateSchemaConfiguration(context.Background(), selectedPackages, manifest.PackagePrefix())
+		err := u.setJsonSchemaDeclarationInVarfiles(selectedPackages, workingDirectory)
 		if err != nil {
 			return err
 		}
 	}
 
 	if opts.MigrateConfig {
-		err := migrate_config.MigrateVarFile(selectedPackages)
+		err := migrate_config.MigrateVarFile(selectedPackages, workingDirectory)
 		if err != nil {
 			return fmt.Errorf("migrating package config: %w", err)
 		}
@@ -130,9 +130,9 @@ func updatePackages(manifest common.PackageManifest, selectedPackages []common.P
 	return updatedManifest, updatedPackages, nil
 }
 
-// updateSchemaConfiguration sets the varFile's JSON schema declaration to the same version as defined in the package
-// manifest.
-func (u Updater) updateSchemaConfiguration(ctx context.Context, selectedPackages []common.Package, manifestPackagePrefix string) error {
+// setJsonSchemaDeclarationInVarfiles sets the varFile's JSON schema declaration to the same version as defined in the
+// package manifest.
+func (u Updater) setJsonSchemaDeclarationInVarfiles(selectedPackages []common.Package, workingDirectory string) error {
 	fmt.Println("Updating json schemas:")
 
 	for _, pkg := range selectedPackages {
@@ -142,7 +142,7 @@ func (u Updater) updateSchemaConfiguration(ctx context.Context, selectedPackages
 			continue
 		}
 
-		varFile, ok := getLastVarFile(pkg)
+		varFile, ok := getLastVarFile(pkg, workingDirectory)
 		if !ok {
 			continue
 		}
@@ -178,10 +178,13 @@ func (u Updater) updateSchemaConfiguration(ctx context.Context, selectedPackages
 	return nil
 }
 
-func getLastVarFile(pkg common.Package) (string, bool) {
+func getLastVarFile(pkg common.Package, workingDirectory string) (string, bool) {
 	if len(pkg.VarFiles) > 0 {
-		return pkg.VarFiles[len(pkg.VarFiles)-1], true
+		varFileRelative := pkg.VarFiles[len(pkg.VarFiles)-1]
+		varFile := path.Join(workingDirectory, varFileRelative)
+		return varFile, true
 	}
+
 	return "", false
 }
 

--- a/pkg/pkg/update/update.go
+++ b/pkg/pkg/update/update.go
@@ -59,7 +59,7 @@ func (u Updater) Run(pkgManifestFilename string, selectedPackagesInput []common.
 	}
 
 	if opts.UpdateSchema {
-		err := u.setJsonSchemaDeclarationInVarfiles(selectedPackages, workingDirectory)
+		err := u.setJsonSchemaDeclarationInVarFiles(selectedPackages, workingDirectory)
 		if err != nil {
 			return err
 		}
@@ -130,9 +130,9 @@ func updatePackages(manifest common.PackageManifest, selectedPackages []common.P
 	return updatedManifest, updatedPackages, nil
 }
 
-// setJsonSchemaDeclarationInVarfiles sets the varFile's JSON schema declaration to the same version as defined in the
+// setJsonSchemaDeclarationInVarFiles sets the varFile's JSON schema declaration to the same version as defined in the
 // package manifest.
-func (u Updater) setJsonSchemaDeclarationInVarfiles(selectedPackages []common.Package, workingDirectory string) error {
+func (u Updater) setJsonSchemaDeclarationInVarFiles(selectedPackages []common.Package, workingDirectory string) error {
 	fmt.Println("Updating json schemas:")
 
 	for _, pkg := range selectedPackages {

--- a/pkg/pkg/update/update_test.go
+++ b/pkg/pkg/update/update_test.go
@@ -145,7 +145,7 @@ func TestGetLastConfigFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, ok := getLastVarFile(tt.pkg)
+			result, ok := getLastVarFile(tt.pkg, "")
 			require.Equal(t, tt.ok, ok)
 			require.Equal(t, tt.expected, result)
 		})


### PR DESCRIPTION
# Description

#391 added `ok pkg install --recursive`, now doing the same for `ok pkg update`.

# Motivation

It makes sense for the `update` command to behave similarly as `install`.
