### PR TITLE
Add `ok pk install` experimental subcommand for new package file format

### DIFF
--- a/cmd/pk.go
+++ b/cmd/pk.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var pkCommand = &cobra.Command{
+	Use:   "pk",
+	Short: "Group of package related commands for managing Boilerplate packages.",
+}

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -1,6 +1,7 @@
 package pk
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/oslokommune/ok/pkg/pk"
@@ -19,28 +20,28 @@ func NewInstallCommand() *cobra.Command {
 
 			okDir, err := pk.OkDir(ctx)
 			if err != nil {
-				return fmt.Errorf("locating .ok directory: %w", err)
+				return errors.Join(fmt.Errorf("locating .ok directory"), err)
 			}
 
 			repoDir, err := pk.RepoRoot(ctx)
 			if err != nil {
-				return fmt.Errorf("finding repository root: %w", err)
+				return errors.Join(fmt.Errorf("finding repository root"), err)
 			}
 
 			configs, err := pk.LoadConfigs(okDir)
 			if err != nil {
-				return fmt.Errorf("loading configs: %w", err)
+				return errors.Join(fmt.Errorf("loading configs"), err)
 			}
 
 			effectiveCfgs, err := pk.ApplyCommon(configs)
 			if err != nil {
-				return fmt.Errorf("applying common configs: %w", err)
+				return errors.Join(fmt.Errorf("applying common configs"), err)
 			}
 
 			for _, cfg := range effectiveCfgs {
 				args, err := pk.BuildBoilerplateArgs(cfg)
 				if err != nil {
-					return fmt.Errorf("building boilerplate args: %w", err)
+					return errors.Join(fmt.Errorf("building boilerplate args"), err)
 				}
 
 				if dryRun {
@@ -49,7 +50,7 @@ func NewInstallCommand() *cobra.Command {
 				}
 
 				if err := pk.RunBoilerplateCommand(ctx, args, repoDir); err != nil {
-					return fmt.Errorf("running boilerplate command: %w", err)
+					return errors.Join(fmt.Errorf("running boilerplate command"), err)
 				}
 			}
 

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -12,34 +12,47 @@ func NewInstallCommand() *cobra.Command {
 		Use:   "install",
 		Short: "Hello World install command",
 		Long:  "This is a simple Hello World install command.",
-		Run: func(cmd *cobra.Command, args []string) {
-			okDir, err := pk.OkDir()
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-				return
-			}
+	}
 
-			// Load configs from the .ok directory
-			configs, err := pk.LoadConfigs(okDir)
-			if err != nil {
-				fmt.Printf("Error loading configs: %v\n", err)
-				return
-			}
+	cmd.Flags().Bool("dry-run", false, "Print the boilerplate command arguments without executing them")
 
-			// Generate merged template configurations
-			mergedConfigs, err := pk.ApplyCommon(configs)
-			if err != nil {
-				fmt.Printf("Error generating merged configs: %v\n", err)
-				return
-			}
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		okDir, err := pk.OkDir()
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
 
-			// Print the boilerplate args that will be run
-			fmt.Println("Boilerplate Command Arguments:")
-			for _, config := range mergedConfigs {
-				args := pk.BuildBoilerplateArgs(config)
-				fmt.Printf("- %v\n", args)
+		// Load configs from the .ok directory
+		configs, err := pk.LoadConfigs(okDir)
+		if err != nil {
+			fmt.Printf("Error loading configs: %v\n", err)
+			return
+		}
+
+		// Generate merged template configurations
+		mergedConfigs, err := pk.ApplyCommon(configs)
+		if err != nil {
+			fmt.Printf("Error generating merged configs: %v\n", err)
+			return
+		}
+
+		// Check if dry-run flag is set
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		for _, config := range mergedConfigs {
+			args := pk.BuildBoilerplateArgs(config)
+			if dryRun {
+				fmt.Printf("Dry-run: %v\n", args)
+			} else {
+				fmt.Printf("Running boilerplate command with args: %v\n", args)
+				err := pk.RunBoilerplateCommand(args, okDir)
+				if err != nil {
+					fmt.Printf("Error running boilerplate command: %v\n", err)
+					return
+				}
 			}
-		},
+		}
 	}
 
 	return cmd

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -39,10 +39,7 @@ func NewInstallCommand() *cobra.Command {
 			}
 
 			for _, cfg := range effectiveCfgs {
-				args, err := pk.BuildBoilerplateArgs(cfg)
-				if err != nil {
-					return errors.Join(fmt.Errorf("building boilerplate args"), err)
-				}
+				args := pk.BuildBoilerplateArgs(cfg)
 
 				if dryRun {
 					fmt.Fprintf(cmd.OutOrStdout(), "dry-run: %v\n", args)

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -18,7 +18,18 @@ func NewInstallCommand() *cobra.Command {
 				fmt.Printf("Error: %v\n", err)
 				return
 			}
-			fmt.Printf("The .ok directory is located at: %s\n", okDir)
+
+			// Load configs from the .ok directory
+			configs, err := pk.LoadConfigs(okDir)
+			if err != nil {
+				fmt.Printf("Error loading configs: %v\n", err)
+				return
+			}
+
+			// Print the loaded configs
+			for _, config := range configs {
+				fmt.Printf("Loaded Config: %+v\n", config)
+			}
 		},
 	}
 

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -3,6 +3,7 @@ package pk
 import (
 	"fmt"
 
+	"github.com/oslokommune/ok/pkg/pk"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +13,12 @@ func NewInstallCommand() *cobra.Command {
 		Short: "Hello World install command",
 		Long:  "This is a simple Hello World install command.",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Hello World from the install command!")
+			okDir, err := pk.GetOkDirPath()
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+			fmt.Printf("The .ok directory is located at: %s\n", okDir)
 		},
 	}
 

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -13,7 +13,7 @@ func NewInstallCommand() *cobra.Command {
 		Short: "Hello World install command",
 		Long:  "This is a simple Hello World install command.",
 		Run: func(cmd *cobra.Command, args []string) {
-			okDir, err := pk.GetOkDirPath()
+			okDir, err := pk.OkDir()
 			if err != nil {
 				fmt.Printf("Error: %v\n", err)
 				return
@@ -27,7 +27,7 @@ func NewInstallCommand() *cobra.Command {
 			}
 
 			// Generate merged template configurations
-			mergedConfigs, err := pk.GenerateTemplateConfigs(configs)
+			mergedConfigs, err := pk.ApplyCommon(configs)
 			if err != nil {
 				fmt.Printf("Error generating merged configs: %v\n", err)
 				return

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -2,6 +2,7 @@ package pk
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/oslokommune/ok/pkg/pk"
 	"github.com/spf13/cobra"
@@ -45,8 +46,9 @@ func NewInstallCommand() *cobra.Command {
 			if dryRun {
 				fmt.Printf("Dry-run: %v\n", args)
 			} else {
+				gitDir := filepath.Dir(okDir) // Assuming gitDir is the parent directory of okDir
 				fmt.Printf("Running boilerplate command with args: %v\n", args)
-				err := pk.RunBoilerplateCommand(args, okDir)
+				err := pk.RunBoilerplateCommand(args, gitDir)
 				if err != nil {
 					fmt.Printf("Error running boilerplate command: %v\n", err)
 					return

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -15,12 +15,14 @@ func NewInstallCommand() *cobra.Command {
 		Short: "Generate project boilerplate",
 		Long:  "Reads .ok configuration files, merges them and runs the boilerplate generator.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			okDir, err := pk.OkDir()
+			ctx := cmd.Context()
+
+			okDir, err := pk.OkDir(ctx)
 			if err != nil {
 				return fmt.Errorf("locating .ok directory: %w", err)
 			}
 
-			repoDir, err := pk.RepoRoot()
+			repoDir, err := pk.RepoRoot(ctx)
 			if err != nil {
 				return fmt.Errorf("finding repository root: %w", err)
 			}
@@ -46,7 +48,7 @@ func NewInstallCommand() *cobra.Command {
 					continue
 				}
 
-				if err := pk.RunBoilerplateCommand(args, repoDir); err != nil {
+				if err := pk.RunBoilerplateCommand(ctx, args, repoDir); err != nil {
 					return fmt.Errorf("running boilerplate command: %w", err)
 				}
 			}

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -1,0 +1,20 @@
+package pk
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewInstallCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Hello World install command",
+		Long:  "This is a simple Hello World install command.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Hello World from the install command!")
+		},
+	}
+
+	return cmd
+}

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -36,7 +36,10 @@ func NewInstallCommand() *cobra.Command {
 			}
 
 			for _, cfg := range effectiveCfgs {
-				args := pk.BuildBoilerplateArgs(cfg)
+				args, err := pk.BuildBoilerplateArgs(cfg)
+				if err != nil {
+					return fmt.Errorf("building boilerplate args: %w", err)
+				}
 
 				if dryRun {
 					fmt.Fprintf(cmd.OutOrStdout(), "dry-run: %v\n", args)

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -26,9 +26,18 @@ func NewInstallCommand() *cobra.Command {
 				return
 			}
 
-			// Print the loaded configs
-			for _, config := range configs {
-				fmt.Printf("Loaded Config: %+v\n", config)
+			// Generate merged template configurations
+			mergedConfigs, err := pk.GenerateTemplateConfigs(configs)
+			if err != nil {
+				fmt.Printf("Error generating merged configs: %v\n", err)
+				return
+			}
+
+			// Print useful information about the merged configurations
+			fmt.Println("Merged Template Configurations:")
+			for _, config := range mergedConfigs {
+				fmt.Printf("- Name: %s, Repo: %s, Ref: %s, Path: %s, Subfolder: %s, VarFiles: %v\n",
+					config.Name, config.Repo, config.Ref, config.Path, config.Subfolder, config.VarFiles)
 			}
 		},
 	}

--- a/cmd/pk/install.go
+++ b/cmd/pk/install.go
@@ -33,11 +33,11 @@ func NewInstallCommand() *cobra.Command {
 				return
 			}
 
-			// Print useful information about the merged configurations
-			fmt.Println("Merged Template Configurations:")
+			// Print the boilerplate args that will be run
+			fmt.Println("Boilerplate Command Arguments:")
 			for _, config := range mergedConfigs {
-				fmt.Printf("- Name: %s, Repo: %s, Ref: %s, Path: %s, Subfolder: %s, VarFiles: %v\n",
-					config.Name, config.Repo, config.Ref, config.Path, config.Subfolder, config.VarFiles)
+				args := pk.BuildBoilerplateArgs(config)
+				fmt.Printf("- %v\n", args)
 			}
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/oslokommune/ok/cmd/aws"
+	"github.com/oslokommune/ok/cmd/pk"
 	"github.com/oslokommune/ok/cmd/pkg"
 	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
 	"github.com/spf13/cobra"
@@ -72,6 +73,9 @@ func init() {
 	awsCommand.AddCommand(aws.EcsExecCommand)
 	awsCommand.AddCommand(aws.AdminSessionCommand)
 	awsCommand.AddCommand(aws.ConfigGeneratorCommand)
+
+	rootCmd.AddCommand(pkCommand)
+	pkCommand.AddCommand(pk.NewInstallCommand())
 
 	initializeConfiguration()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,10 +74,13 @@ func init() {
 	awsCommand.AddCommand(aws.AdminSessionCommand)
 	awsCommand.AddCommand(aws.ConfigGeneratorCommand)
 
-	rootCmd.AddCommand(pkCommand)
-	pkCommand.AddCommand(pk.NewInstallCommand())
-
+	// Ensure configuration is initialized before adding commands
 	initializeConfiguration()
+
+	if viper.GetBool("enable_experimental") {
+		rootCmd.AddCommand(pkCommand)
+		pkCommand.AddCommand(pk.NewInstallCommand())
+	}
 }
 
 // initializeConfiguration is the function that initializes configuration using viper. It is called at the start of the application.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,6 @@ func init() {
 	awsCommand.AddCommand(aws.AdminSessionCommand)
 	awsCommand.AddCommand(aws.ConfigGeneratorCommand)
 
-	// Ensure configuration is initialized before adding commands
 	initializeConfiguration()
 
 	if viper.GetBool("enable_experimental") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func init() {
 // initializeConfiguration is the function that initializes configuration using viper. It is called at the start of the application.
 func initializeConfiguration() {
 	setConfigFile()
-	viper.SetDefault("enable_experimental", true)
+	viper.SetDefault("enable_experimental", false)
 	viper.SetEnvPrefix("ok")
 	viper.AutomaticEnv()
 	loadConfiguration()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -43,7 +44,7 @@ func Execute() {
 	err := rootCmd.Execute()
 
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println(errors.Join(fmt.Errorf("root command execution failed"), err))
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
+	dario.cat/mergo v1.0.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.54 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
 al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -112,11 +112,12 @@ func BuildBoilerplateArgs(tpl Template) []string {
 	return args
 }
 
-// RunBoilerplateCommand takes arguments as input and executes the boilerplate command.
-func RunBoilerplateCommand(args []string) error {
+// RunBoilerplateCommand takes arguments and a working directory as input and executes the boilerplate command.
+func RunBoilerplateCommand(args []string, workingDir string) error {
 	cmd := exec.Command("boilerplate", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Dir = workingDir // Set the working directory to the provided path
 
 	return cmd.Run()
 }

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -92,10 +92,13 @@ func ApplyCommon(cfgs []Config) ([]Template, error) {
 
 	for _, cfg := range cfgs {
 		for _, tpl := range cfg.Templates {
-			merged := tpl // start with the template
+			merged := tpl
 
-			// copy non-zero fields from cfg.Common into merged
-			if err := mergo.Merge(&merged, cfg.Common); err != nil {
+			if err := mergo.Merge(
+				&merged,
+				cfg.Common,
+				mergo.WithAppendSlice,
+			); err != nil {
 				return nil, err
 			}
 

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -1,0 +1,26 @@
+package pk
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GetGitRoot returns the root directory of the Git repository.
+func GetGitRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GetOkDirPath returns the path to the ".ok" directory inside the Git root.
+func GetOkDirPath() (string, error) {
+	gitRoot, err := GetGitRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(gitRoot, ".ok"), nil
+}

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"dario.cat/mergo"
@@ -50,6 +51,9 @@ func YAMLFiles(dir string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Sort the YAML files to ensure deterministic order
+	sort.Strings(yamlFiles)
 
 	return yamlFiles, nil
 }

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -1,6 +1,7 @@
 package pk
 
 import (
+	"io/fs"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -23,4 +24,23 @@ func GetOkDirPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(gitRoot, ".ok"), nil
+}
+
+// FindYamlFiles returns a slice of paths to all YAML files in the specified directory.
+func FindYamlFiles(dir string) ([]string, error) {
+	var yamlFiles []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && (filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml") {
+			yamlFiles = append(yamlFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return yamlFiles, nil
 }

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dario.cat/mergo"
+	"dario.cat/mergo"
 	"gopkg.in/yaml.v3"
 )
 
@@ -74,35 +74,15 @@ func LoadConfigs(dir string) ([]Config, error) {
 	return configs, nil
 }
 
-// TemplateConfig represents a template configuration with common settings merged in.
-type TemplateConfig struct {
-	Repo             string   `yaml:"repo"`
-	Path             string   `yaml:"path"`
-	NonInteractive   bool     `yaml:"non_interactive"`
-	Ref              string   `yaml:"ref"`
-	VarFiles         []string `yaml:"var_files"`
-	BaseOutputFolder string   `yaml:"base_output_folder"`
-	Name             string   `yaml:"name"`
-	Subfolder        string   `yaml:"subfolder"`
-}
-
 // GenerateTemplateConfigs generates a list of template configurations with common settings merged in.
-func GenerateTemplateConfigs(cfgs []Config) ([]TemplateConfig, error) {
-	var out []TemplateConfig
+func GenerateTemplateConfigs(cfgs []Config) ([]Template, error) {
+	var out []Template
 	for _, cfg := range cfgs {
 		for _, tpl := range cfg.Templates {
-			merged := TemplateConfig{
-				Name:      tpl.Name,
-				Subfolder: tpl.Subfolder,
-			} // Initialize with template-specific fields
+			merged := tpl // Start with the template
 
 			// Merge common config into the template
 			if err := mergo.Merge(&merged, cfg.Common, mergo.WithOverride); err != nil {
-				return nil, err
-			}
-
-			// Merge template-specific fields
-			if err := mergo.Merge(&merged, tpl, mergo.WithOverride); err != nil {
 				return nil, err
 			}
 

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -18,7 +18,7 @@ func RepoRoot() (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
 	}
 	return strings.TrimSpace(string(output)), nil
 }
@@ -27,7 +27,7 @@ func RepoRoot() (string, error) {
 func OkDir() (string, error) {
 	gitRoot, err := RepoRoot()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("RepoRoot failed: %w", err)
 	}
 	return filepath.Join(gitRoot, ".ok"), nil
 }
@@ -37,7 +37,7 @@ func YAMLFiles(dir string) ([]string, error) {
 	var yamlFiles []string
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("walking directory %s: %w", dir, err)
 		}
 		if !d.IsDir() && (filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml") {
 			yamlFiles = append(yamlFiles, path)
@@ -60,14 +60,14 @@ func LoadConfigs(dir string) ([]Config, error) {
 
 	var configs []Config
 	for _, file := range yamlFiles {
-		data, err := os.ReadFile(file) // Updated from ioutil.ReadFile to os.ReadFile
+		data, err := os.ReadFile(file)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reading file %s: %w", file, err)
 		}
 
 		var config Config
 		if err := yaml.Unmarshal(data, &config); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unmarshalling YAML from file %s: %w", file, err)
 		}
 
 		configs = append(configs, config)

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -93,3 +93,32 @@ func ApplyCommon(cfgs []Config) ([]Template, error) {
 	}
 	return out, nil
 }
+
+// BuildBoilerplateArgs takes a Template and constructs the arguments for the boilerplate command.
+func BuildBoilerplateArgs(tpl Template) []string {
+	args := []string{
+		"--template-url", tpl.Repo + "//" + tpl.Path + "?ref=" + tpl.Ref,
+		"--output-folder", filepath.Join(tpl.BaseOutputFolder, tpl.Subfolder),
+	}
+
+	if tpl.NonInteractive {
+		args = append(args, "--non-interactive")
+	}
+
+	for _, varFile := range tpl.VarFiles {
+		args = append(args, "--var-file", varFile)
+	}
+
+	return args
+}
+
+// RunBoilerplateCommand takes a Template, builds the arguments, and executes the boilerplate command.
+func RunBoilerplateCommand(tpl Template) error {
+	args := BuildBoilerplateArgs(tpl)
+
+	cmd := exec.Command("boilerplate", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -119,7 +119,7 @@ func buildGitSource(repo, subPath, ref string) string {
 	return fmt.Sprintf("%s//%s", repo, subPath)
 }
 
-func BuildBoilerplateArgs(tpl Template) ([]string, error) {
+func BuildBoilerplateArgs(tpl Template) []string {
 	source := buildGitSource(tpl.Repo, tpl.Path, tpl.Ref)
 
 	args := []string{
@@ -133,7 +133,7 @@ func BuildBoilerplateArgs(tpl Template) ([]string, error) {
 	for _, vf := range tpl.VarFiles {
 		args = append(args, "--var-file", vf)
 	}
-	return args, nil
+	return args
 }
 
 // RunBoilerplateCommand takes arguments and a working directory as input and executes the boilerplate command.

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -2,9 +2,12 @@ package pk
 
 import (
 	"io/fs"
+	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // GetGitRoot returns the root directory of the Git repository.
@@ -43,4 +46,29 @@ func FindYamlFiles(dir string) ([]string, error) {
 	}
 
 	return yamlFiles, nil
+}
+
+// LoadConfigs loads YAML files from the specified directory into a slice of Config structures.
+func LoadConfigs(dir string) ([]Config, error) {
+	yamlFiles, err := FindYamlFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var configs []Config
+	for _, file := range yamlFiles {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+
+		var config Config
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return nil, err
+		}
+
+		configs = append(configs, config)
+	}
+
+	return configs, nil
 }

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -112,10 +112,8 @@ func BuildBoilerplateArgs(tpl Template) []string {
 	return args
 }
 
-// RunBoilerplateCommand takes a Template, builds the arguments, and executes the boilerplate command.
-func RunBoilerplateCommand(tpl Template) error {
-	args := BuildBoilerplateArgs(tpl)
-
+// RunBoilerplateCommand takes arguments as input and executes the boilerplate command.
+func RunBoilerplateCommand(args []string) error {
 	cmd := exec.Command("boilerplate", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/pk/common.go
+++ b/pkg/pk/common.go
@@ -1,6 +1,7 @@
 package pk
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"net/url"
@@ -14,8 +15,8 @@ import (
 )
 
 // RepoRoot returns the root directory of the Git repository.
-func RepoRoot() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+func RepoRoot(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
@@ -24,8 +25,8 @@ func RepoRoot() (string, error) {
 }
 
 // OkDir returns the path to the ".ok" directory inside the Git root.
-func OkDir() (string, error) {
-	gitRoot, err := RepoRoot()
+func OkDir(ctx context.Context) (string, error) {
+	gitRoot, err := RepoRoot(ctx)
 	if err != nil {
 		return "", fmt.Errorf("RepoRoot failed: %w", err)
 	}
@@ -128,11 +129,11 @@ func BuildBoilerplateArgs(tpl Template) ([]string, error) {
 }
 
 // RunBoilerplateCommand takes arguments and a working directory as input and executes the boilerplate command.
-func RunBoilerplateCommand(args []string, workingDir string) error {
-	cmd := exec.Command("boilerplate", args...)
+func RunBoilerplateCommand(ctx context.Context, args []string, workingDir string) error {
+	cmd := exec.CommandContext(ctx, "boilerplate", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Dir = workingDir // Set the working directory to the provided path
+	cmd.Dir = workingDir
 
 	return cmd.Run()
 }

--- a/pkg/pk/types.go
+++ b/pkg/pk/types.go
@@ -1,0 +1,23 @@
+package pk
+
+type CommonConfig struct {
+	Repo             string   `yaml:"repo"`
+	Path             string   `yaml:"path"`
+	NonInteractive   bool     `yaml:"non_interactive"`
+	Ref              string   `yaml:"ref"`
+	VarFiles         []string `yaml:"var_files"`
+	BaseOutputFolder string   `yaml:"base_output_folder"`
+}
+
+type Template struct {
+	Name           string   `yaml:"name"`
+	VarFiles       []string `yaml:"var_files,omitempty"`
+	NonInteractive bool     `yaml:"non_interactive,omitempty"`
+	Ref            string   `yaml:"ref"`
+	Subfolder      string   `yaml:"subfolder"`
+}
+
+type Config struct {
+	Common    CommonConfig `yaml:"common"`
+	Templates []Template   `yaml:"templates"`
+}

--- a/pkg/pk/types.go
+++ b/pkg/pk/types.go
@@ -1,23 +1,17 @@
 package pk
 
-type CommonConfig struct {
+type Template struct {
 	Repo             string   `yaml:"repo"`
 	Path             string   `yaml:"path"`
 	NonInteractive   bool     `yaml:"non_interactive"`
 	Ref              string   `yaml:"ref"`
 	VarFiles         []string `yaml:"var_files"`
 	BaseOutputFolder string   `yaml:"base_output_folder"`
-}
-
-type Template struct {
-	Name           string   `yaml:"name"`
-	VarFiles       []string `yaml:"var_files,omitempty"`
-	NonInteractive bool     `yaml:"non_interactive,omitempty"`
-	Ref            string   `yaml:"ref"`
-	Subfolder      string   `yaml:"subfolder"`
+	Name             string   `yaml:"name"`
+	Subfolder        string   `yaml:"subfolder"`
 }
 
 type Config struct {
-	Common    CommonConfig `yaml:"common"`
-	Templates []Template   `yaml:"templates"`
+	Common    Template   `yaml:"common"`
+	Templates []Template `yaml:"templates"`
 }


### PR DESCRIPTION
This assumes the config will look like what's in https://github.com/oslokommune/ok/issues/418, but that can be changed (later). It does not matter at this point. It matters when we move this command over to `ok pkg` instead of having it named `ok pk` and hidden behind the experimental flag.

Commits will be squashed.

```
export OK_ENABLE_EXPERIMENTAL=true
go run main.go pk install --dry-run
go run main.go pk install
```

Looks for configs in `.ok` and runs Boilerplate commands based on the contents. 

Plan:

We release this and test it in `pirates-iac`.