### PR TITLE
feat: update default location of package manifest and var files

### DIFF
--- a/cmd/pkg/add.go
+++ b/cmd/pkg/add.go
@@ -56,11 +56,13 @@ ok pkg add app ecommerce-api
 			}
 
 			slog.Info(fmt.Sprintf("%s (%s) added to %s with output folder name %s\n", result.TemplateName, result.TemplateVersion, packagesManifestFilename, result.OutputFolder))
-			nonExistingConfigFiles := findNonExistingConfigurationFiles(result.VarFiles)
-			if len(nonExistingConfigFiles) > 0 {
-				slog.Info("\nCreate the following configuration files:\n")
-				for _, configFile := range nonExistingConfigFiles {
-					slog.Info(fmt.Sprintf("- %s\n", configFile))
+			if consolidatedPackageStructure {
+				nonExistingConfigFiles := findNonExistingConfigurationFiles(result.VarFiles)
+				if len(nonExistingConfigFiles) > 0 {
+					slog.Info("\nCreate the following configuration files:\n")
+					for _, configFile := range nonExistingConfigFiles {
+						slog.Info(fmt.Sprintf("- %s\n", configFile))
+					}
 				}
 			}
 			return nil

--- a/cmd/pkg/add.go
+++ b/cmd/pkg/add.go
@@ -3,10 +3,12 @@ package pkg
 import (
 	"errors"
 	"fmt"
-	"github.com/oslokommune/ok/pkg/pkg/common"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/oslokommune/ok/pkg/pkg/common"
 
 	"github.com/oslokommune/ok/pkg/pkg/add"
 	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
@@ -33,13 +35,27 @@ ok pkg add app ecommerce-api
 		RunE: func(cmd *cobra.Command, args []string) error {
 			templateName := getArg(args, 0, "")
 			outputFolder := getArg(args, 1, templateName)
+			currentDir, err := os.Getwd()
+			if err != nil {
+				cmd.PrintErrf("failed to get current dir: %s\n", err)
+				return nil
+			}
+			consolidatedPackageStructure, err := common.UseConsolidatedPackageStructure(currentDir)
+			if err != nil {
+				cmd.PrintErrf("failed to check if we should be using consolidated package structure: %s\n", err)
+				return nil
+			}
+			var packagesManifestFilename = common.PackagesManifestFilename
+			if !consolidatedPackageStructure {
+				packagesManifestFilename = filepath.Join(outputFolder, packagesManifestFilename)
+			}
 
-			result, err := adder.Run(common.PackagesManifestFilename, templateName, outputFolder, flagAddCommandUpdateSchema)
+			result, err := adder.Run(packagesManifestFilename, templateName, outputFolder, flagAddCommandUpdateSchema, consolidatedPackageStructure)
 			if err != nil {
 				return err
 			}
 
-			slog.Info(fmt.Sprintf("%s (%s) added to %s with output folder name %s\n", result.TemplateName, result.TemplateVersion, common.PackagesManifestFilename, result.OutputFolder))
+			slog.Info(fmt.Sprintf("%s (%s) added to %s with output folder name %s\n", result.TemplateName, result.TemplateVersion, packagesManifestFilename, result.OutputFolder))
 			nonExistingConfigFiles := findNonExistingConfigurationFiles(result.VarFiles)
 			if len(nonExistingConfigFiles) > 0 {
 				slog.Info("\nCreate the following configuration files:\n")

--- a/pkg/pkg/add/add.go
+++ b/pkg/pkg/add/add.go
@@ -94,7 +94,7 @@ func createNewPackage(manifest common.PackageManifest, templateName, gitRef, out
 		commonConfigFile = common.VarFile(manifest.PackageConfigPrefix(), "common-config")
 		out = manifest.PackageOutputFolder(outputFolder)
 	} else {
-		configFile = common.VarFile("", "config")
+		configFile = common.VarFile("", common.DefaultVarFileName)
 		commonConfigFile = common.VarFile(common.GenerateRelativePath(outputFolder), "common-config")
 		out = "."
 
@@ -120,7 +120,7 @@ func (a Adder) updateSchemaConfig(manifest common.PackageManifest, pkg common.Pa
 	if consolidatedPackageStructure {
 		varFilePath = common.VarFile(manifest.PackageConfigPrefix(), outputFolder)
 	} else {
-		varFilePath = common.VarFile(outputFolder, "config")
+		varFilePath = common.VarFile(outputFolder, common.DefaultVarFileName)
 	}
 
 	err := schema.SetSchemaDeclarationInVarFile(varFilePath, pkg.Ref)

--- a/pkg/pkg/add/add.go
+++ b/pkg/pkg/add/add.go
@@ -2,9 +2,10 @@ package add
 
 import (
 	"fmt"
-	"github.com/oslokommune/ok/pkg/pkg/schema"
 	"os"
 	"strings"
+
+	"github.com/oslokommune/ok/pkg/pkg/schema"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
 	"github.com/oslokommune/ok/pkg/pkg/githubreleases"
@@ -30,7 +31,7 @@ func NewAdder() Adder {
 	return Adder{}
 }
 
-func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string, updateSchema bool) (*AddResult, error) {
+func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string, updateSchema bool, consolidatedPackageStructure bool) (*AddResult, error) {
 	templateVersion, err := getTemplateVersion(templateName)
 	if err != nil {
 		return nil, err
@@ -42,7 +43,7 @@ func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string
 		return nil, err
 	}
 
-	newPackage, err := createNewPackage(manifest, templateName, pkgRef, outputFolder)
+	newPackage, err := createNewPackage(manifest, templateName, pkgRef, outputFolder, consolidatedPackageStructure)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string
 	}
 
 	if updateSchema {
-		if err := a.updateSchemaConfig(manifest, newPackage, outputFolder); err != nil {
+		if err := a.updateSchemaConfig(manifest, newPackage, outputFolder, consolidatedPackageStructure); err != nil {
 			return nil, err
 		}
 	}
@@ -86,9 +87,18 @@ func getTemplateVersion(templateName string) (string, error) {
 	return templateVersion, nil
 }
 
-func createNewPackage(manifest common.PackageManifest, templateName, gitRef, outputFolder string) (common.Package, error) {
-	configFile := common.VarFile(manifest.PackageConfigPrefix(), outputFolder)
-	commonConfigFile := common.VarFile(manifest.PackageConfigPrefix(), "common-config")
+func createNewPackage(manifest common.PackageManifest, templateName, gitRef, outputFolder string, consolidatedPackageStructure bool) (common.Package, error) {
+	var configFile, commonConfigFile, out string
+	if consolidatedPackageStructure {
+		configFile = common.VarFile(manifest.PackageConfigPrefix(), outputFolder)
+		commonConfigFile = common.VarFile(manifest.PackageConfigPrefix(), "common-config")
+		out = manifest.PackageOutputFolder(outputFolder)
+	} else {
+		configFile = common.VarFile("", "config")
+		commonConfigFile = common.VarFile(common.GenerateRelativePath(outputFolder), "common-config")
+		out = "."
+
+	}
 
 	varFiles := []string{
 		commonConfigFile,
@@ -98,17 +108,22 @@ func createNewPackage(manifest common.PackageManifest, templateName, gitRef, out
 	newPackage := common.Package{
 		Template:     templateName,
 		Ref:          gitRef,
-		OutputFolder: manifest.PackageOutputFolder(outputFolder),
+		OutputFolder: out,
 		VarFiles:     varFiles,
 	}
 
 	return newPackage, nil
 }
 
-func (a Adder) updateSchemaConfig(manifest common.PackageManifest, pkg common.Package, outputFolder string) error {
-	varFilepath := common.VarFile(manifest.PackageConfigPrefix(), outputFolder)
+func (a Adder) updateSchemaConfig(manifest common.PackageManifest, pkg common.Package, outputFolder string, consolidatedPackageStructure bool) error {
+	var varFilePath string
+	if consolidatedPackageStructure {
+		varFilePath = common.VarFile(manifest.PackageConfigPrefix(), outputFolder)
+	} else {
+		varFilePath = common.VarFile(outputFolder, "config")
+	}
 
-	err := schema.SetSchemaDeclarationInVarFile(varFilepath, pkg.Ref)
+	err := schema.SetSchemaDeclarationInVarFile(varFilePath, pkg.Ref)
 	if err != nil {
 		return fmt.Errorf("creating or updating configuration file: %w", err)
 	}

--- a/pkg/pkg/add/add_test.go
+++ b/pkg/pkg/add/add_test.go
@@ -1,6 +1,8 @@
 package add
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
@@ -9,21 +11,23 @@ import (
 
 func TestCreateNewPackage(t *testing.T) {
 	tests := []struct {
-		name         string
-		manifest     common.PackageManifest
-		templateName string
-		gitRef       string
-		outputFolder string
-		expected     common.Package
+		name                         string
+		manifest                     common.PackageManifest
+		templateName                 string
+		gitRef                       string
+		outputFolder                 string
+		consolidatedPackageStructure bool
+		expected                     common.Package
 	}{
 		{
 			name: "default package",
 			manifest: common.PackageManifest{
 				DefaultPackagePathPrefix: "",
 			},
-			templateName: "template1",
-			gitRef:       "template1-v1.0.0",
-			outputFolder: "folder1",
+			templateName:                 "template1",
+			gitRef:                       "template1-v1.0.0",
+			outputFolder:                 "folder1",
+			consolidatedPackageStructure: true,
 			expected: common.Package{
 				Template:     "template1",
 				Ref:          "template1-v1.0.0",
@@ -36,9 +40,10 @@ func TestCreateNewPackage(t *testing.T) {
 			manifest: common.PackageManifest{
 				DefaultPackagePathPrefix: common.BoilerplatePackageGitHubActionsPath,
 			},
-			templateName: "template2",
-			gitRef:       "template2-v2.0.0",
-			outputFolder: "folder2",
+			templateName:                 "template2",
+			gitRef:                       "template2-v2.0.0",
+			outputFolder:                 "folder2",
+			consolidatedPackageStructure: true,
 			expected: common.Package{
 				Template:     "template2",
 				Ref:          "template2-v2.0.0",
@@ -51,9 +56,10 @@ func TestCreateNewPackage(t *testing.T) {
 			manifest: common.PackageManifest{
 				DefaultPackagePathPrefix: "custom/prefix",
 			},
-			templateName: "template3",
-			gitRef:       "template3-v3.0.0",
-			outputFolder: "folder3",
+			templateName:                 "template3",
+			gitRef:                       "template3-v3.0.0",
+			outputFolder:                 "folder3",
+			consolidatedPackageStructure: true,
 			expected: common.Package{
 				Template:     "template3",
 				Ref:          "template3-v3.0.0",
@@ -61,11 +67,43 @@ func TestCreateNewPackage(t *testing.T) {
 				VarFiles:     []string{"_config/common-config.yml", "_config/folder3.yml"},
 			},
 		},
+		{
+			name: "packages.yml in separate folder",
+			manifest: common.PackageManifest{
+				DefaultPackagePathPrefix: "",
+			},
+			templateName:                 "template4",
+			gitRef:                       "template4-v4.0.0",
+			outputFolder:                 "folder4",
+			consolidatedPackageStructure: false,
+			expected: common.Package{
+				Template:     "template4",
+				Ref:          "template4-v4.0.0",
+				OutputFolder: ".",
+				VarFiles:     []string{"../common-config.yml", "config.yml"},
+			},
+		},
+		{
+			name: "packages.yml in separate, nested folder",
+			manifest: common.PackageManifest{
+				DefaultPackagePathPrefix: "",
+			},
+			templateName:                 "template5",
+			gitRef:                       "template5-v5.0.0",
+			outputFolder:                 "dir/folder5",
+			consolidatedPackageStructure: false,
+			expected: common.Package{
+				Template:     "template5",
+				Ref:          "template5-v5.0.0",
+				OutputFolder: ".",
+				VarFiles:     []string{"../../common-config.yml", "config.yml"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := createNewPackage(tt.manifest, tt.templateName, tt.gitRef, tt.outputFolder)
+			result, err := createNewPackage(tt.manifest, tt.templateName, tt.gitRef, tt.outputFolder, tt.consolidatedPackageStructure)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
@@ -122,6 +160,84 @@ func TestAllowDuplicateOutputFolder(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateSchemaConfig(t *testing.T) {
+	// Create temporary test directory
+	testDir, err := os.MkdirTemp("", "schema-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	tests := []struct {
+		name                         string
+		consolidatedPackageStructure bool
+		outputFolder                 string
+		expectedFilePath             string
+		expectedError                bool
+	}{
+		{
+			name:                         "consolidated package structure",
+			consolidatedPackageStructure: true,
+			outputFolder:                 "my-output",
+			expectedFilePath:             "_config/my-output.yml",
+			expectedError:                false,
+		},
+		{
+			name:                         "non-consolidated package structure",
+			consolidatedPackageStructure: false,
+			outputFolder:                 "my-output",
+			expectedFilePath:             "my-output/config.yml",
+			expectedError:                false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a subdirectory for each test case
+			testCaseDir := filepath.Join(testDir, tt.name)
+			err := os.MkdirAll(testCaseDir, 0755)
+			require.NoError(t, err)
+
+			// Change to test case directory
+			originalDir, err := os.Getwd()
+			require.NoError(t, err)
+			err = os.Chdir(testCaseDir)
+			require.NoError(t, err)
+			defer os.Chdir(originalDir) // Restore original directory at end
+
+			// Create test manifest
+			manifest := common.PackageManifest{}
+
+			// Create test package
+			pkg := common.Package{
+				Template: "test-template",
+				Ref:      "test-template-v1.0.0",
+			}
+
+			// Create adder and run update
+			adder := NewAdder()
+			err = adder.updateSchemaConfig(manifest, pkg, tt.outputFolder, tt.consolidatedPackageStructure)
+
+			// Check results
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				// Verify file was created
+				fullPath := filepath.Join(testCaseDir, tt.expectedFilePath)
+				fileInfo, err := os.Stat(fullPath)
+				require.NoError(t, err)
+				require.False(t, fileInfo.IsDir())
+
+				// Read file content and verify it contains schema reference
+				content, err := os.ReadFile(fullPath)
+				require.NoError(t, err)
+				require.Contains(t, string(content), "schema")
+				require.Contains(t, string(content), pkg.Ref)
 			}
 		})
 	}

--- a/pkg/pkg/add/add_test.go
+++ b/pkg/pkg/add/add_test.go
@@ -80,7 +80,7 @@ func TestCreateNewPackage(t *testing.T) {
 				Template:     "template4",
 				Ref:          "template4-v4.0.0",
 				OutputFolder: ".",
-				VarFiles:     []string{"../common-config.yml", "config.yml"},
+				VarFiles:     []string{"../common-config.yml", common.DefaultVarFileName + ".yml"},
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestCreateNewPackage(t *testing.T) {
 				Template:     "template5",
 				Ref:          "template5-v5.0.0",
 				OutputFolder: ".",
-				VarFiles:     []string{"../../common-config.yml", "config.yml"},
+				VarFiles:     []string{"../../common-config.yml", common.DefaultVarFileName + ".yml"},
 			},
 		},
 	}
@@ -189,7 +189,7 @@ func TestUpdateSchemaConfig(t *testing.T) {
 			name:                         "non-consolidated package structure",
 			consolidatedPackageStructure: false,
 			outputFolder:                 "my-output",
-			expectedFilePath:             "my-output/config.yml",
+			expectedFilePath:             "my-output/" + common.DefaultVarFileName + ".yml",
 			expectedError:                false,
 		},
 	}

--- a/pkg/pkg/common/common.go
+++ b/pkg/pkg/common/common.go
@@ -82,19 +82,19 @@ func dirExists(path string) (bool, error) {
 
 func UseConsolidatedPackageStructure(dir string) (bool, error) {
 	packagePath := filepath.Join(dir, PackagesManifestFilename)
-	configDir := filepath.Join(dir, BoilerplatePackageTerraformConfigPrefix)
+	varFileDir := filepath.Join(dir, BoilerplatePackageTerraformConfigPrefix)
 
 	packageExists, err := fileExists(packagePath)
 	if err != nil {
 		return false, err
 	}
 
-	configDirExists, err := dirExists(configDir)
+	varFileDirExists, err := dirExists(varFileDir)
 	if err != nil {
 		return false, err
 	}
 
-	if packageExists && configDirExists {
+	if packageExists && varFileDirExists {
 		return true, nil
 	}
 

--- a/pkg/pkg/common/common.go
+++ b/pkg/pkg/common/common.go
@@ -20,6 +20,8 @@ const BoilerplatePackageGitHubActionsPath = "boilerplate/github-actions"
 const BoilerplatePackageGitHubActionsConfigPrefix = ""
 const BoilerplatePackageGitHubActionsOutputFolder = "../.."
 
+const DefaultVarFileName = "package-config"
+
 const DefaultBaseUrl = "git@github.com:oslokommune/golden-path-boilerplate.git//"
 const DefaultPackagePathPrefix = BoilerplatePackageTerraformPath
 const DefaultPackageConfigPrefix = BoilerplatePackageTerraformConfigPrefix

--- a/pkg/pkg/common/common_test.go
+++ b/pkg/pkg/common/common_test.go
@@ -44,44 +44,48 @@ func TestUseConsolidatedPackageStructure(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		setup          func(baseDir string)
+		setup          func(baseDir string, t *testing.T)
 		expectedResult bool
 		expectedError  bool
 	}{
 		{
 			name: "should use existing packages.yml when packages.yml and _config found in dir",
-			setup: func(baseDir string) {
+			setup: func(baseDir string, t *testing.T) {
 				os.WriteFile(filepath.Join(baseDir, PackagesManifestFilename), []byte(""), 0644)
+				require.NoError(t, err)
 				os.MkdirAll(filepath.Join(baseDir, BoilerplatePackageTerraformConfigPrefix), 0755)
+				require.NoError(t, err)
 			},
 			expectedResult: true,
 			expectedError:  false,
 		},
 		{
 			name: "should use existing packages.yml for github actions",
-			setup: func(baseDir string) {
+			setup: func(baseDir string, t *testing.T) {
 				content := "DefaultPackagePathPrefix: " + BoilerplatePackageGitHubActionsPath
 				os.WriteFile(filepath.Join(baseDir, PackagesManifestFilename), []byte(content), 0644)
+				require.NoError(t, err)
 			},
 			expectedResult: true,
 			expectedError:  false,
 		},
 		{
 			name:           "should not use consolidated packages.yml by default",
-			setup:          func(baseDir string) {},
+			setup:          func(baseDir string, t *testing.T) {},
 			expectedResult: false,
 			expectedError:  false,
 		},
 		{
 			name:           "should not use consolidated packages.yml when only packages.yml is present in dir",
-			setup:          func(baseDir string) {},
+			setup:          func(baseDir string, t *testing.T) {},
 			expectedResult: false,
 			expectedError:  false,
 		},
 		{
 			name: "should not use consolidated packages.yml when only _config is present in dir",
-			setup: func(baseDir string) {
+			setup: func(baseDir string, t *testing.T) {
 				os.MkdirAll(filepath.Join(baseDir, BoilerplatePackageTerraformConfigPrefix), 0755)
+				require.NoError(t, err)
 			},
 			expectedResult: false,
 			expectedError:  false,
@@ -95,7 +99,7 @@ func TestUseConsolidatedPackageStructure(t *testing.T) {
 			err := os.MkdirAll(testCaseDir, 0755)
 			require.NoError(t, err)
 
-			tt.setup(testCaseDir)
+			tt.setup(testCaseDir, t)
 
 			result, err := UseConsolidatedPackageStructure(testCaseDir)
 

--- a/pkg/pkg/common/common_test.go
+++ b/pkg/pkg/common/common_test.go
@@ -1,8 +1,11 @@
 package common
 
 import (
-	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigFile(t *testing.T) {
@@ -30,6 +33,79 @@ func TestConfigFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := VarFile(tt.prefix, tt.configName)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUseConsolidatedPackageStructure(t *testing.T) {
+	testDir, err := os.MkdirTemp("", "package-structure-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	tests := []struct {
+		name           string
+		setup          func(baseDir string)
+		expectedResult bool
+		expectedError  bool
+	}{
+		{
+			name: "should use existing packages.yml when packages.yml and _config found in dir",
+			setup: func(baseDir string) {
+				os.WriteFile(filepath.Join(baseDir, PackagesManifestFilename), []byte(""), 0644)
+				os.MkdirAll(filepath.Join(baseDir, BoilerplatePackageTerraformConfigPrefix), 0755)
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "should use existing packages.yml for github actions",
+			setup: func(baseDir string) {
+				content := "DefaultPackagePathPrefix: " + BoilerplatePackageGitHubActionsPath
+				os.WriteFile(filepath.Join(baseDir, PackagesManifestFilename), []byte(content), 0644)
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name:           "should not use consolidated packages.yml by default",
+			setup:          func(baseDir string) {},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name:           "should not use consolidated packages.yml when only packages.yml is present in dir",
+			setup:          func(baseDir string) {},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "should not use consolidated packages.yml when only _config is present in dir",
+			setup: func(baseDir string) {
+				os.MkdirAll(filepath.Join(baseDir, BoilerplatePackageTerraformConfigPrefix), 0755)
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a subdirectory for each test case
+			testCaseDir := filepath.Join(testDir, tt.name)
+			err := os.MkdirAll(testCaseDir, 0755)
+			require.NoError(t, err)
+
+			tt.setup(testCaseDir)
+
+			result, err := UseConsolidatedPackageStructure(testCaseDir)
+
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expectedResult, result)
 		})
 	}
 }

--- a/pkg/pkg/common/save_manifest.go
+++ b/pkg/pkg/common/save_manifest.go
@@ -3,11 +3,17 @@ package common
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
 
 func SavePackageManifest(filePath string, manifest PackageManifest) (err error) {
+	dir := filepath.Dir(filePath)
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
 	// if the file already exists it will be overwritten
 	// and the file PERM will be retained
 	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)


### PR DESCRIPTION
An attempt to introduce a new default location of `packages.yml`, as well as package configuration file, when using `ok pkg add` while being backwards-compatible with the old location.

## Example
Example old structure for `stacks/dev`:
- `stacks/dev/packages.yml`
- `stacks/dev/_config/common-config.yml`
- `stacks/dev/_config/app-example.yml`

Example new structure for `stacks/dev`:
- `stacks/dev/common-config.yml`
- `stacks/dev/app-example/config.yml`
- `stacks/dev/app-example/packages.yml`

## Implementation
The new behavior of `ok pkg add` is as follows:
- If the current working directory contains a `packages.yml` and a `_config` directory, we fall back to the old behavior.
- If the current working directory contains a `packages.yml` and the key `DefaultPackagePathPrefix` is set to `boilerplate/github-actions`, we fall back to the old behavior.
- In all other cases, we use the new behavior which places `packages.yml` as well as the package configuration file inside the output directory (e.g., `app-example`).

The tests could probably be improved, but I _think_ the coverage is good enough. I was looking into using the pattern from https://github.com/oslokommune/ok/tree/main/cmd/pkg/testdata for some high-level tests, but it seems to require more changes than it might be worth.

## Remaining issues
Here are some remaining issues that I am unsure if we should fix or not as they might require larger changes throughout the codebase:
- `findNonExistingConfigurationFiles` incorrectly reports files missing because it assumes all paths are relative to the current working directory.
- When inside a directory such as `stacks/dev`, you can no longer run targeted installations (e.g., `ok pkg install <my-stack>`). You can, however, use `ok pkg install --recursive` or `cd` into the folder you want to install a package in and run `ok pkg install`.
- Tab completion for `ok pkg install` does not work when running from a directory such as `stacks/dev`.