### PR TITLE
ci: trigger release on changes from release please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,15 @@ on:
   push:
     branches:
       - main
+    # NOTE: We only trigger on specific file paths to avoid unncessarily running the workflow
     paths:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
       - '**/*.sh'
       - '**/*.rb'
+      # NOTE: We need to trigger a release when a PR from release-please has been merged
+      - ".release-please-manifest.json"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is needed to properly create GitHub and Homebrew releases when a release-please PR has been merged (e.g., https://github.com/oslokommune/ok/pull/431).

(We can optionally consider removing the `paths` argument from the workflow in its entirety or perhaps add a comment on why it's there in the first place)