### PR TITLE
feat: Pretty print errors

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIterate(t *testing.T) {
+	t.Run("test errors", func(t *testing.T) {
+
+		a := fmt.Errorf("deepest error a")
+		b := fmt.Errorf("middle b that wraps a: %w", a)
+		c := fmt.Errorf("middle c that wraps b: %w", b)
+		d := fmt.Errorf("top level d that wraps c: %w", c)
+
+		fmt.Println("--------")
+		prettyPrintError(d)
+		fmt.Println("--------")
+	})
+}


### PR DESCRIPTION
# Beskrivelse

Før:

![image](https://github.com/user-attachments/assets/f4d81418-5167-4c42-9817-6fa7d2a3cfcc)

Litt før dette hadde vi:

![image](https://github.com/user-attachments/assets/4402eb99-b464-481f-9b52-b96b586a1e33)

Med denne PR-en:

![image](https://github.com/user-attachments/assets/f1abb60b-3446-4cbb-b706-2e0123e74984)

# Motivasjon

https://oslokommune.slack.com/archives/CV9EGL9UG/p1741267437944039

Forhåpentligvis forbedret UX:

* Gjør det litt tydelige at det har skjedd en feil
* Gjør feilmeldingen lettere å lese

Closes [#2261](https://github.com/oslokommune/golden-path-iac/issues/2261)

