### PR TITLE
chore: Rename add flag to --add-schema

### DIFF
--- a/cmd/pkg/add.go
+++ b/cmd/pkg/add.go
@@ -69,7 +69,7 @@ ok pkg add app ecommerce-api
 		},
 	}
 
-	cmd.Flags().BoolVar(&flagAddCommandUpdateSchema, "update-schema", true, "Update the JSON schema for affected packages")
+	cmd.Flags().BoolVar(&flagAddCommandUpdateSchema, "add-schema", true, "Update the JSON schema for affected packages")
 
 	return cmd
 }

--- a/pkg/pkg/add/add.go
+++ b/pkg/pkg/add/add.go
@@ -31,7 +31,7 @@ func NewAdder() Adder {
 	return Adder{}
 }
 
-func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string, updateSchema bool, consolidatedPackageStructure bool) (*AddResult, error) {
+func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string, addSchema bool, consolidatedPackageStructure bool) (*AddResult, error) {
 	templateVersion, err := getTemplateVersion(templateName)
 	if err != nil {
 		return nil, err
@@ -57,8 +57,8 @@ func (a Adder) Run(pkgManifestFilename string, templateName, outputFolder string
 		return nil, err
 	}
 
-	if updateSchema {
-		if err := a.updateSchemaConfig(manifest, newPackage, outputFolder, consolidatedPackageStructure); err != nil {
+	if addSchema {
+		if err := a.addSchemaConfig(manifest, newPackage, outputFolder, consolidatedPackageStructure); err != nil {
 			return nil, err
 		}
 	}
@@ -115,7 +115,7 @@ func createNewPackage(manifest common.PackageManifest, templateName, gitRef, out
 	return newPackage, nil
 }
 
-func (a Adder) updateSchemaConfig(manifest common.PackageManifest, pkg common.Package, outputFolder string, consolidatedPackageStructure bool) error {
+func (a Adder) addSchemaConfig(manifest common.PackageManifest, pkg common.Package, outputFolder string, consolidatedPackageStructure bool) error {
 	var varFilePath string
 	if consolidatedPackageStructure {
 		varFilePath = common.VarFile(manifest.PackageConfigPrefix(), outputFolder)

--- a/pkg/pkg/add/add_test.go
+++ b/pkg/pkg/add/add_test.go
@@ -219,7 +219,7 @@ func TestUpdateSchemaConfig(t *testing.T) {
 
 			// Create adder and run update
 			adder := NewAdder()
-			err = adder.updateSchemaConfig(manifest, pkg, tt.outputFolder, tt.consolidatedPackageStructure)
+			err = adder.addSchemaConfig(manifest, pkg, tt.outputFolder, tt.consolidatedPackageStructure)
 
 			// Check results
 			if tt.expectedError {


### PR DESCRIPTION
Endrer navn fra `ok pkg add --update-schema` til `ok pkg add --add-schema`, da update ikke gir mening for en ny pakke.

Lager ikke major bump av dette da jeg ikke fant noen referanser til at noen bruker dette flagget.