### PR TITLE
feat(pkg install): warn when boilerplate has invalid semver version

### DIFF
--- a/pkg/pkg/install/install.go
+++ b/pkg/pkg/install/install.go
@@ -13,6 +13,8 @@ import (
 
 // Run runs Boilerplate for the specified packages.
 func Run(packagesToInstall []common.Package, manifest common.PackageManifest, workingDirectory string) error {
+	warnIfInvalidBoilerplateVersion()
+
 	cmds, err := CreateBoilerplateCommands(packagesToInstall, CreateBoilerPlateCommandsOpts{
 		PackagePathPrefix: manifest.PackagePrefix(),
 		BaseUrlOrPath:     os.Getenv(common.BaseUrlEnvName),
@@ -123,3 +125,4 @@ type CreateBoilerPlateCommandsOpts struct {
 	BaseUrlOrPath     string
 	WorkingDirectory  string
 }
+

--- a/pkg/pkg/install/version_check.go
+++ b/pkg/pkg/install/version_check.go
@@ -1,0 +1,54 @@
+package install
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var warnStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("3")) // Yellow
+
+// warnIfInvalidBoilerplateVersion prints a warning if boilerplate has an invalid semver version.
+// Some self-built versions report "latest" which causes failures when a Boilerplate template uses `required_version`
+func warnIfInvalidBoilerplateVersion() {
+	version, err := getBoilerplateVersion()
+	if err != nil {
+		// Don't block install if we can't determine the version
+		return
+	}
+
+	_, err = semver.NewVersion(version)
+	if err != nil {
+		fmt.Println(warnStyle.Render(fmt.Sprintf(
+			"️⚠️ Warning: boilerplate version %q is not a valid semantic version.", version)))
+		fmt.Println("Some Golden Path templates may fail because they require a valid version (e.g. v0.12.1).")
+		fmt.Println("This can happen if boilerplate was built from source without a proper version tag.")
+		fmt.Println()
+	}
+}
+
+// getBoilerplateVersion runs "boilerplate --version" and extracts the version string.
+func getBoilerplateVersion() (string, error) {
+	out, err := exec.Command("boilerplate", "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("running 'boilerplate --version': %w", err)
+	}
+
+	return parseBoilerplateVersion(string(out)), nil
+}
+
+// parseBoilerplateVersion extracts the version from boilerplate --version output.
+// Expected format: "boilerplate version v0.12.1" or "boilerplate version latest".
+func parseBoilerplateVersion(output string) string {
+	output = strings.TrimSpace(output)
+	parts := strings.Fields(output)
+
+	if len(parts) >= 3 {
+		return parts[len(parts)-1]
+	}
+
+	return output
+}

--- a/pkg/pkg/install/version_check_test.go
+++ b/pkg/pkg/install/version_check_test.go
@@ -1,0 +1,43 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBoilerplateVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard version",
+			input:    "boilerplate version v0.12.1",
+			expected: "v0.12.1",
+		},
+		{
+			name:     "latest version",
+			input:    "boilerplate version latest",
+			expected: "latest",
+		},
+		{
+			name:     "with trailing newline",
+			input:    "boilerplate version v0.12.0\n",
+			expected: "v0.12.0",
+		},
+		{
+			name:     "just version string",
+			input:    "v1.0.0",
+			expected: "v1.0.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseBoilerplateVersion(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
When boilerplate is built from source without a proper version tag, it reports "latest" as its version. This causes golden-path-boilerplate templates to fail with a cryptic "Malformed version: latest" error, after partially running and deleting files.

This happens because boilerplate checks version when the template has a `required_version`, like this: https://github.com/oslokommune/golden-path-boilerplate/blob/e86addeaeba9a8ebfa6b9e1e3e3ab0795f57cf9e/boilerplate/terraform/versions/boilerplate.yml#L1

Add a pre-flight version check that warns the user before running boilerplate, so they know what's wrong and how to fix it.

Details: https://oslokommune.slack.com/archives/C06A1NDQMN1/p1773927548378819?thread_ts=1773926696.325429&cid=C06A1NDQMN1

# Motivation

Aid users to detect and understand this error themselves.