### PR TITLE
feat(forward): label writer/reader in cluster endpoint picker

### DIFF
--- a/internal/scriptrunner/port-forward.sh
+++ b/internal/scriptrunner/port-forward.sh
@@ -251,7 +251,10 @@ if [ -z "$LOCAL_PORT" ] || [ -z "$REMOTE_PORT" ] || [ -z "$RDS_ENDPOINT" ]; then
     }
 
     # Label each cluster instance "(writer)"/"(reader)" via IsClusterWriter; leave
-    # standalone (non-cluster) instances as bare endpoints.
+    # standalone (non-cluster) instances as bare endpoints. Each line looks like:
+    #   mydb-instance-1.xxxx.eu-west-1.rds.amazonaws.com (writer)
+    #   mydb-instance-2.xxxx.eu-west-1.rds.amazonaws.com (reader)
+    #   standalone-db.xxxx.eu-west-1.rds.amazonaws.com
     endpoints=$(echo "$instancesJson" | jq -r --argjson clusters "$clustersJson" '
         ($clusters.DBClusters // []
             | map(.DBClusterMembers[]? | {key: .DBInstanceIdentifier, value: (if .IsClusterWriter then "writer" else "reader" end)})

--- a/internal/scriptrunner/port-forward.sh
+++ b/internal/scriptrunner/port-forward.sh
@@ -238,10 +238,17 @@ fi
 if [ -z "$LOCAL_PORT" ] || [ -z "$REMOTE_PORT" ] || [ -z "$RDS_ENDPOINT" ]; then
 
     printMessage "Loading RDS endpoints ..."
-    instancesJson=$(aws rds describe-db-instances)
+    instancesJson=$(aws rds describe-db-instances) || {
+        printMessage "Failed to load RDS instances. Check your AWS credentials and permissions." red
+        exit 1
+    }
     # Cluster info gives us the writer/reader role per instance. It's optional:
-    # if the call fails (e.g. missing IAM permission) we fall back to bare endpoints.
-    clustersJson=$(aws rds describe-db-clusters 2>/dev/null || echo '{"DBClusters":[]}')
+    # if the call fails (e.g. missing IAM permission) we fall back to bare endpoints
+    # and warn so missing labels aren't mistaken for standalone instances.
+    clustersJson=$(aws rds describe-db-clusters 2>/dev/null) || {
+        printMessage "Could not load cluster roles; writer/reader labels unavailable." yellow
+        clustersJson='{"DBClusters":[]}'
+    }
 
     # Label each cluster instance "(writer)"/"(reader)" via IsClusterWriter; leave
     # standalone (non-cluster) instances as bare endpoints.

--- a/internal/scriptrunner/port-forward.sh
+++ b/internal/scriptrunner/port-forward.sh
@@ -238,17 +238,35 @@ fi
 if [ -z "$LOCAL_PORT" ] || [ -z "$REMOTE_PORT" ] || [ -z "$RDS_ENDPOINT" ]; then
 
     printMessage "Loading RDS endpoints ..."
-    endpoints=$(aws rds describe-db-instances | jq -r '.DBInstances[].Endpoint.Address')
+    instancesJson=$(aws rds describe-db-instances)
+    # Cluster info gives us the writer/reader role per instance. It's optional:
+    # if the call fails (e.g. missing IAM permission) we fall back to bare endpoints.
+    clustersJson=$(aws rds describe-db-clusters 2>/dev/null || echo '{"DBClusters":[]}')
+
+    # Label each cluster instance "(writer)"/"(reader)" via IsClusterWriter; leave
+    # standalone (non-cluster) instances as bare endpoints.
+    endpoints=$(echo "$instancesJson" | jq -r --argjson clusters "$clustersJson" '
+        ($clusters.DBClusters // []
+            | map(.DBClusterMembers[]? | {key: .DBInstanceIdentifier, value: (if .IsClusterWriter then "writer" else "reader" end)})
+            | from_entries) as $roles
+        | .DBInstances[]
+        | .Endpoint.Address as $addr
+        | ($roles[.DBInstanceIdentifier]) as $role
+        | if $role then "\($addr) (\($role))" else $addr end
+    ')
     if [ -z "$endpoints" ]; then
         printMessage "No RDS endpoints found" red
         exit 1
     fi
-    RDS_ENDPOINT=$(echo "$endpoints" | fzf)
+    selection=$(echo "$endpoints" | fzf)
 
-    if [ -z "$RDS_ENDPOINT" ]; then
+    if [ -z "$selection" ]; then
         printMessage "No RDS endpoint selected" red
         exit 1
     fi
+
+    # Strip the "(writer)"/"(reader)" label; endpoint hostnames contain no spaces.
+    RDS_ENDPOINT=$(echo "$selection" | cut -d' ' -f1)
 
     while true; do
         read -rp "$(echo -e "Enter local port or press enter to use:" "$colorGreen$localPortDefault$colorReset")" LOCAL_PORT


### PR DESCRIPTION
## Description

`ok forward` against a cluster listed RDS instance endpoints as bare hostnames, with no way to tell a writer from a reader before connecting.

This labels each cluster instance `(writer)`/`(reader)` in the `fzf` picker, joining `describe-db-instances` with `IsClusterWriter` from `describe-db-clusters`:

```
mydb-instance-1.xxxx.eu-west-1.rds.amazonaws.com (writer)
mydb-instance-2.xxxx.eu-west-1.rds.amazonaws.com (reader)
standalone-db.xxxx.eu-west-1.rds.amazonaws.com
```

- Standalone (non-cluster) instances stay bare — unchanged behavior.
- The label is stripped from the selection (`cut -d' ' -f1`), so the forwarded host is the bare endpoint as before. Endpoint hostnames contain no spaces.

### Error handling

Following code review, the two AWS lookups now fail clearly:

- **`describe-db-clusters` is optional.** If it fails (e.g. missing IAM permission), the picker warns that writer/reader labels are unavailable and falls back to the previous bare list — so a labelless writer isn't mistaken for a standalone instance.
- **`describe-db-instances` is required.** If it fails, a distinct error points at credentials/permissions instead of the misleading "No RDS endpoints found".

Only `internal/scriptrunner/port-forward.sh` changed; no Go changes (the script is embedded as-is).

## Motivation

Avoid guessing or checking the AWS console, and avoid connecting to the wrong instance (e.g. writing against a reader).

## Testing

- `bash -n` and `shellcheck` clean
- `go build ./...` passes (embed compiles)
- `jq` join exercised against fixture JSON: writer/reader labels, standalone bare, label-strip, and the empty-clusters fallback all verified
- Both `||` failure paths exercised in isolation: cluster failure → warning + bare list; instances failure → exit 1; success → no warning

Closes #503