### PR TITLE
feat(pkg): announce when ok pkg add creates a new package manifest

### DIFF
--- a/pkg/pkg/add/add.go
+++ b/pkg/pkg/add/add.go
@@ -60,6 +60,11 @@ func (a Adder) Run(opts Options) error {
 		packagesManifestFilename = filepath.Join(opts.OutputFolder, common.PackagesManifestFilename)
 	}
 
+	manifestExists, err := common.ManifestExists(packagesManifestFilename)
+	if err != nil {
+		return fmt.Errorf("checking if package manifest exists: %w", err)
+	}
+
 	manifest, err := common.LoadPackageManifest(packagesManifestFilename)
 	if err != nil {
 		return err
@@ -94,7 +99,11 @@ func (a Adder) Run(opts Options) error {
 
 	manifest.Packages = append(manifest.Packages, newPackage)
 
-	fmt.Printf("Creating package manifest %s\n", packagesManifestFilename)
+	if manifestExists {
+		fmt.Printf("Updating package manifest %s\n", packagesManifestFilename)
+	} else {
+		fmt.Printf("Creating new package manifest %s\n", packagesManifestFilename)
+	}
 	err = common.SavePackageManifest(packagesManifestFilename, manifest)
 	if err != nil {
 		return fmt.Errorf("saving package manifest: %w", err)
@@ -131,6 +140,20 @@ func (a Adder) Run(opts Options) error {
 		partMsg,
 		common.StyleHighlight.Render(manifest.PackageOutputFolder(opts.OutputFolder)),
 	)
+
+	if !manifestExists {
+		fmt.Println()
+		fmt.Printf("%sA new package manifest was created at %s.\n",
+			common.StyleHighlight.Render("Note: "),
+			common.StyleHighlight.Render(packagesManifestFilename),
+		)
+		fmt.Printf("If you are adding GitHub Actions packages, set %s in it before installing.\n",
+			common.StyleHighlight.Render(
+				fmt.Sprintf("DefaultPackagePathPrefix: %s", common.BoilerplatePackageGitHubActionsPath),
+			),
+		)
+	}
+
 	fmt.Println()
 	fmt.Printf("%sOpen %s to configure your stack.\n",
 		common.StyleHighlight.Render("Next step: "),

--- a/pkg/pkg/add/add.go
+++ b/pkg/pkg/add/add.go
@@ -99,11 +99,7 @@ func (a Adder) Run(opts Options) error {
 
 	manifest.Packages = append(manifest.Packages, newPackage)
 
-	if manifestExists {
-		fmt.Printf("Updating package manifest %s\n", packagesManifestFilename)
-	} else {
-		fmt.Printf("Creating new package manifest %s\n", packagesManifestFilename)
-	}
+	fmt.Println(manifestSaveMessage(manifestExists, packagesManifestFilename))
 	err = common.SavePackageManifest(packagesManifestFilename, manifest)
 	if err != nil {
 		return fmt.Errorf("saving package manifest: %w", err)
@@ -141,17 +137,9 @@ func (a Adder) Run(opts Options) error {
 		common.StyleHighlight.Render(manifest.PackageOutputFolder(opts.OutputFolder)),
 	)
 
-	if !manifestExists {
+	if notice := newManifestNotice(manifestExists, packagesManifestFilename); notice != "" {
 		fmt.Println()
-		fmt.Printf("%sA new package manifest was created at %s.\n",
-			common.StyleHighlight.Render("Note: "),
-			common.StyleHighlight.Render(packagesManifestFilename),
-		)
-		fmt.Printf("If you are adding GitHub Actions packages, set %s in it before installing.\n",
-			common.StyleHighlight.Render(
-				fmt.Sprintf("DefaultPackagePathPrefix: %s", common.BoilerplatePackageGitHubActionsPath),
-			),
-		)
+		fmt.Println(notice)
 	}
 
 	fmt.Println()
@@ -161,6 +149,35 @@ func (a Adder) Run(opts Options) error {
 	)
 
 	return nil
+}
+
+// manifestSaveMessage returns the status line printed when saving a package manifest,
+// distinguishing between updating an existing manifest and creating a brand new one.
+func manifestSaveMessage(manifestExists bool, manifestPath string) string {
+	action := "Creating new"
+	if manifestExists {
+		action = "Updating"
+	}
+	return fmt.Sprintf("%s package manifest %s", action, manifestPath)
+}
+
+// newManifestNotice returns guidance shown after a fresh manifest is created, or an empty
+// string when the manifest already existed. A fresh manifest defaults to Terraform packages,
+// so the notice nudges users adding a GitHub Actions package to set the correct prefix.
+func newManifestNotice(manifestExists bool, manifestPath string) string {
+	if manifestExists {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%sThe new manifest defaults to %s packages.\n"+
+			"If this is a GitHub Actions package, set %s in %s before installing.",
+		common.StyleHighlight.Render("Note: "),
+		common.StyleHighlight.Render(common.BoilerplatePackageTerraformPath),
+		common.StyleHighlight.Render(
+			fmt.Sprintf("DefaultPackagePathPrefix: %s", common.BoilerplatePackageGitHubActionsPath),
+		),
+		common.StyleHighlight.Render(manifestPath),
+	)
 }
 
 func createErrorIfOutputFolderExists(manifest common.PackageManifest, outputFolder string) error {

--- a/pkg/pkg/add/add_test.go
+++ b/pkg/pkg/add/add_test.go
@@ -1,8 +1,8 @@
 package add
 
 import (
+	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -114,95 +114,108 @@ func TestCreateNewPackage(t *testing.T) {
 	}
 }
 
-func TestRunAnnouncesManifestCreation(t *testing.T) {
+// gitHubReleasesStub is a mockable implementation of the add.GitHubReleases dependency that
+// NewAdder accepts. Injecting it lets tests exercise Adder.Run without network access or
+// changing the working directory, so they can run in parallel.
+type gitHubReleasesStub struct {
+	latestReleases map[string]string
+}
+
+func (g *gitHubReleasesStub) GetLatestReleases() (map[string]string, error) {
+	return g.latestReleases, nil
+}
+
+func (g *gitHubReleasesStub) DownloadGithubFile(context.Context, string, string, string, string) ([]byte, error) {
+	return nil, fmt.Errorf("DownloadGithubFile should not be called in this test")
+}
+
+// TestRunCreatesManifestUsingInjectedDependency exercises the manifest-creation branch of
+// Adder.Run end-to-end using the injected GitHubReleases dependency (per review feedback) and
+// an absolute output folder, so the test needs neither network access nor a directory change
+// and can run in parallel.
+func TestRunCreatesManifestUsingInjectedDependency(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	outputFolder := filepath.Join(repoDir, "databases")
+
+	ghReleases := &gitHubReleasesStub{
+		latestReleases: map[string]string{"databases": "v4.0.0"},
+	}
+	adder := NewAdder(ghReleases)
+
+	// repoDir has no packages.yml and no _config dir, so the legacy (non-consolidated)
+	// structure is used and the manifest is written under the absolute output folder.
+	err := adder.Run(Options{
+		CurrentDir:      repoDir,
+		TemplateName:    "databases",
+		OutputFolder:    outputFolder,
+		DownloadVarFile: false,
+	})
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(outputFolder, common.PackagesManifestFilename)
+	require.FileExists(t, manifestPath)
+
+	manifest, err := common.LoadPackageManifest(manifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.Packages, 1)
+	require.Equal(t, "databases", manifest.Packages[0].Template)
+	require.Equal(t, "databases-v4.0.0", manifest.Packages[0].Ref)
+}
+
+// TestManifestSaveMessage covers the created-vs-updated status line without printing, so it is
+// parallel-safe and does not depend on the working directory.
+func TestManifestSaveMessage(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name             string
-		setup            func(t *testing.T, dir string)
-		expectedOutput   []string
-		unexpectedOutput []string
+		name           string
+		manifestExists bool
+		manifestPath   string
+		want           string
 	}{
 		{
-			name:  "should announce when a new package manifest is created",
-			setup: func(t *testing.T, dir string) {},
-			expectedOutput: []string{
-				"Creating new package manifest",
-				"A new package manifest was created at",
-				fmt.Sprintf("DefaultPackagePathPrefix: %s", common.BoilerplatePackageGitHubActionsPath),
-			},
-			unexpectedOutput: []string{
-				"Updating package manifest",
-			},
+			name:           "new manifest",
+			manifestExists: false,
+			manifestPath:   "databases/packages.yml",
+			want:           "Creating new package manifest databases/packages.yml",
 		},
 		{
-			name: "should not announce manifest creation when updating an existing package manifest",
-			setup: func(t *testing.T, dir string) {
-				manifestPath := filepath.Join(dir, common.PackagesManifestFilename)
-				err := common.SavePackageManifest(manifestPath, common.PackageManifest{})
-				require.NoError(t, err)
-
-				err = os.MkdirAll(filepath.Join(dir, common.BoilerplatePackageTerraformConfigPrefix), 0755)
-				require.NoError(t, err)
-			},
-			expectedOutput: []string{
-				"Updating package manifest",
-			},
-			unexpectedOutput: []string{
-				"Creating new package manifest",
-				"A new package manifest was created at",
-			},
+			name:           "existing manifest",
+			manifestExists: true,
+			manifestPath:   "packages.yml",
+			want:           "Updating package manifest packages.yml",
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testDir := t.TempDir()
-
-			// Change to test directory
-			originalDir, err := os.Getwd()
-			require.NoError(t, err)
-			err = os.Chdir(testDir)
-			require.NoError(t, err)
-			defer func(dir string) {
-				err := os.Chdir(dir)
-				require.NoError(t, err)
-			}(originalDir) // Restore the original directory at the end
-
-			tt.setup(t, testDir)
-
-			// Capture stdout
-			originalStdout := os.Stdout
-			pipeReader, pipeWriter, err := os.Pipe()
-			require.NoError(t, err)
-			os.Stdout = pipeWriter
-
-			// Setting BaseUrl skips the GitHub release lookup, and disabling DownloadVarFile
-			// skips the var file download, so Run does not need network access.
-			adder := NewAdder(nil)
-			runErr := adder.Run(Options{
-				BaseUrl:         "../boilerplate/terraform",
-				CurrentDir:      testDir,
-				TemplateName:    "databases",
-				OutputFolder:    "databases",
-				DownloadVarFile: false,
-			})
-
-			os.Stdout = originalStdout
-			err = pipeWriter.Close()
-			require.NoError(t, err)
-			outputBytes, err := io.ReadAll(pipeReader)
-			require.NoError(t, err)
-			output := string(outputBytes)
-
-			require.NoError(t, runErr)
-
-			for _, expected := range tt.expectedOutput {
-				require.Contains(t, output, expected)
-			}
-			for _, unexpected := range tt.unexpectedOutput {
-				require.NotContains(t, output, unexpected)
-			}
+			t.Parallel()
+			require.Equal(t, tt.want, manifestSaveMessage(tt.manifestExists, tt.manifestPath))
 		})
 	}
+}
+
+// TestNewManifestNotice covers the GitHub Actions guidance shown only when a fresh manifest is
+// created. It asserts on stable substrings so it is unaffected by terminal styling.
+func TestNewManifestNotice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("shown when a new manifest is created", func(t *testing.T) {
+		t.Parallel()
+		notice := newManifestNotice(false, "databases/packages.yml")
+		require.Contains(t, notice, "GitHub Actions")
+		require.Contains(t, notice, common.BoilerplatePackageTerraformPath)
+		require.Contains(t, notice, fmt.Sprintf("DefaultPackagePathPrefix: %s", common.BoilerplatePackageGitHubActionsPath))
+		require.Contains(t, notice, "databases/packages.yml")
+	})
+
+	t.Run("empty when the manifest already exists", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, newManifestNotice(true, "packages.yml"))
+	})
 }
 
 func TestAllowDuplicateOutputFolder(t *testing.T) {

--- a/pkg/pkg/add/add_test.go
+++ b/pkg/pkg/add/add_test.go
@@ -1,10 +1,13 @@
 package add
 
 import (
-	"github.com/oslokommune/ok/pkg/pkg/schema"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/oslokommune/ok/pkg/pkg/schema"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
 	"github.com/stretchr/testify/require"
@@ -107,6 +110,97 @@ func TestCreateNewPackage(t *testing.T) {
 			result, err := createNewPackage(tt.manifest, tt.templateName, tt.gitRef, tt.outputFolder, tt.consolidatedPackageStructure)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRunAnnouncesManifestCreation(t *testing.T) {
+	tests := []struct {
+		name             string
+		setup            func(t *testing.T, dir string)
+		expectedOutput   []string
+		unexpectedOutput []string
+	}{
+		{
+			name:  "should announce when a new package manifest is created",
+			setup: func(t *testing.T, dir string) {},
+			expectedOutput: []string{
+				"Creating new package manifest",
+				"A new package manifest was created at",
+				fmt.Sprintf("DefaultPackagePathPrefix: %s", common.BoilerplatePackageGitHubActionsPath),
+			},
+			unexpectedOutput: []string{
+				"Updating package manifest",
+			},
+		},
+		{
+			name: "should not announce manifest creation when updating an existing package manifest",
+			setup: func(t *testing.T, dir string) {
+				manifestPath := filepath.Join(dir, common.PackagesManifestFilename)
+				err := common.SavePackageManifest(manifestPath, common.PackageManifest{})
+				require.NoError(t, err)
+
+				err = os.MkdirAll(filepath.Join(dir, common.BoilerplatePackageTerraformConfigPrefix), 0755)
+				require.NoError(t, err)
+			},
+			expectedOutput: []string{
+				"Updating package manifest",
+			},
+			unexpectedOutput: []string{
+				"Creating new package manifest",
+				"A new package manifest was created at",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+
+			// Change to test directory
+			originalDir, err := os.Getwd()
+			require.NoError(t, err)
+			err = os.Chdir(testDir)
+			require.NoError(t, err)
+			defer func(dir string) {
+				err := os.Chdir(dir)
+				require.NoError(t, err)
+			}(originalDir) // Restore the original directory at the end
+
+			tt.setup(t, testDir)
+
+			// Capture stdout
+			originalStdout := os.Stdout
+			pipeReader, pipeWriter, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdout = pipeWriter
+
+			// Setting BaseUrl skips the GitHub release lookup, and disabling DownloadVarFile
+			// skips the var file download, so Run does not need network access.
+			adder := NewAdder(nil)
+			runErr := adder.Run(Options{
+				BaseUrl:         "../boilerplate/terraform",
+				CurrentDir:      testDir,
+				TemplateName:    "databases",
+				OutputFolder:    "databases",
+				DownloadVarFile: false,
+			})
+
+			os.Stdout = originalStdout
+			err = pipeWriter.Close()
+			require.NoError(t, err)
+			outputBytes, err := io.ReadAll(pipeReader)
+			require.NoError(t, err)
+			output := string(outputBytes)
+
+			require.NoError(t, runErr)
+
+			for _, expected := range tt.expectedOutput {
+				require.Contains(t, output, expected)
+			}
+			for _, unexpected := range tt.unexpectedOutput {
+				require.NotContains(t, output, unexpected)
+			}
 		})
 	}
 }

--- a/pkg/pkg/common/load_manifest.go
+++ b/pkg/pkg/common/load_manifest.go
@@ -8,6 +8,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ManifestExists returns true if a package manifest exists at the given path.
+//
+// LoadPackageManifest returns an empty manifest when the file does not exist, so callers that
+// need to distinguish between updating an existing manifest and creating a new one should use
+// this function.
+func ManifestExists(filePath string) (bool, error) {
+	return fileExists(filePath)
+}
+
 func LoadPackageManifest(filePath string) (PackageManifest, error) {
 	fileContents, err := os.ReadFile(filePath)
 	if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
## Problem

When running `ok pkg add` and no `packages.yml` exists, the CLI silently creates one. The message `Creating package manifest <path>` was printed unconditionally, even when an existing manifest was being updated, so users could not tell the two cases apart.

This bites hardest when adding GitHub Actions packages: a freshly created manifest lacks `DefaultPackagePathPrefix: boilerplate/github-actions`, so the implicit default (`boilerplate/terraform`) is used and the install fails in confusing ways.

## Approach

The original issue #356 concluded "notice only, no magic" (it explicitly rejected directory detection and a `--type` flag). In review, @yngvark asked that ok configure the prefix itself rather than ask the user.

I investigated auto-configuring it and found it can't be done cleanly right now:

- The prefix is **manifest-wide** (`DefaultPackagePathPrefix`); there is no per-package prefix.
- ok cannot tell a GitHub Actions template from a Terraform one at add time: `GetLatestReleases()` returns a flat, type-less map. The only source of truth is the boilerplate layout (`boilerplate/github-actions/*` vs `boilerplate/terraform/*`).
- Auto-detecting the type therefore requires either a **new network round-trip per `ok pkg add`** or a **hardcoded GHA template-name list** — and the hardcoded list is exactly what #416 aims to remove.

So this PR ships the safe improvement now and routes the real auto-detect to a follow-up tied to #416:

- Distinguish create vs update: print `Creating new package manifest <path>` vs `Updating package manifest <path>`.
- On fresh-manifest creation, print a short, tightened notice: the manifest defaults to `boilerplate/terraform`, and for a GitHub Actions package you should set `DefaultPackagePathPrefix: boilerplate/github-actions` before installing. It does **not** claim ok does this automatically.

Researched proposal: https://github.com/oslokommune/brolagtsti/issues/50

## Changes

- `pkg/pkg/common/load_manifest.go`: new `ManifestExists(path)` helper next to `LoadPackageManifest`, so callers can distinguish "file missing" from "empty manifest" without changing the `LoadPackageManifest` signature (~7 call sites).
- `pkg/pkg/add/add.go` (`Adder.Run`): checks the **resolved** manifest path (after the `UseConsolidatedPackageStructure` branching, so both layouts are handled) and branches the message. The created-vs-updated status line and the notice are extracted into pure helpers (`manifestSaveMessage`, `newManifestNotice`).
- `pkg/pkg/add/add_test.go`: reworked per review — the create path is tested end-to-end via the injected mockable `GitHubReleases` dependency with an absolute output folder (no `os.Chdir`), and the message/notice branches are unit-tested through the pure helpers. All new tests use `t.Parallel()`.

## Before / after

Before (same message whether creating or updating):

```
Creating package manifest databases/packages.yml

✅ Successfully added package databases-v4.0.0 to directory databases.

Next step: Open databases/package-config.yml to configure your stack.
```

After — no `packages.yml` exists (created):

```
Creating new package manifest databases/packages.yml

✅ Successfully added package databases-v4.0.0 to directory databases.

Note: The new manifest defaults to boilerplate/terraform packages.
If this is a GitHub Actions package, set DefaultPackagePathPrefix: boilerplate/github-actions in databases/packages.yml before installing.

Next step: Open databases/package-config.yml to configure your stack.
```

After — `packages.yml` already exists (updated):

```
Updating package manifest packages.yml

✅ Successfully added package databases-v4.0.0 with output directory databases.

Next step: Open _config/databases.yml to configure your stack.
```

## Follow-up

Full auto-detection of GitHub Actions vs Terraform packages (so ok can set `DefaultPackagePathPrefix` itself) will be filed as a follow-up, to be solved together with #416 (removing the hardcoded `PackageConfigPrefix` logic), since a clean solution shares the same "know the package type without hardcoding" problem.

## Testing

- `go build ./...`, `go vet ./...` pass
- `go test ./...` passes (including the existing end-to-end tests in `cmd/pkg/add_test.go`)

Closes #356
Closes oslokommune/brolagtsti#50
