### PR TITLE
fix(pkg): select schema var file by declaration instead of position

### DIFF
--- a/cmd/pkg/testdata/update/bump-ref-field/expected/config/app-hello.yml
+++ b/cmd/pkg/testdata/update/bump-ref-field/expected/config/app-hello.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/app-v9.0.0.schema.json
 StackName: "app-hello"
 app-data.StackName: "app-hello-data"
 AppName: "hello"
@@ -10,13 +9,6 @@ ServiceConnect:
   Enable: true
 AlbHostRouting:
   Enable: true
-  Internal: false
-  Subdomain:
-    Enable: true
-    TargetGroupTargetStickiness: false
-  ApexDomain:
-    Enable: false
-    TargetGroupTargetStickiness: false
 DatabaseConnectivity:
   Enable: true
 OpenTelemetrySidecar:

--- a/cmd/pkg/testdata/update/bump-ref-field/expected/config/load-balancing-alb-main.yml
+++ b/cmd/pkg/testdata/update/bump-ref-field/expected/config/load-balancing-alb-main.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/load-balancing-alb-v4.0.0.schema.json
+StackName: "load-balancing-alb-main"
+load-balancing-alb-data.StackName: "load-balancing-alb-main-data"
+
+Name: "main"
+Internal: false
+Terragrunt:
+  Enable: true
+IncludeLockFile: false

--- a/cmd/pkg/update_test.go
+++ b/cmd/pkg/update_test.go
@@ -26,6 +26,7 @@ func TestUpdateCommand(t *testing.T) {
 				"packages.yml",
 				"config/app-hello.yml",
 				"config/common-config.yml",
+				"config/load-balancing-alb-main.yml",
 			},
 		},
 		{

--- a/pkg/pkg/update/update.go
+++ b/pkg/pkg/update/update.go
@@ -142,29 +142,20 @@ func (u Updater) setJsonSchemaDeclarationInVarFiles(selectedPackages []common.Pa
 			continue
 		}
 
-		varFile, ok := getLastVarFile(pkg, workingDirectory)
-		if !ok {
+		varFile, existingSchema, found := findSchemaVarFile(pkg, workingDirectory)
+		if !found {
+			_, _ = fmt.Fprintf(os.Stderr,
+				"⚠️ Warning: no var file of package '%s' declares a JSON schema for template '%s'."+
+					" Skipping schema update for this package."+
+					" Add a '# yaml-language-server: $schema=...' declaration to the package's own var file to enable schema updates.\n",
+				pkg.OutputFolder, pkg.Template)
 			continue
 		}
 
 		fmt.Printf("- %s\n", pkg.OutputFolder)
 
-		// Get current JSON schema for the package
-		jsonSchemaMetdata, err := metadata.ParseFirstLine(varFile)
-		if err != nil && errors.Is(err, metadata.ErrMissingSchemaDeclaration) {
-			err = schema.SetSchemaDeclarationInVarFile(varFile, pkg.Ref)
-			if err != nil {
-				return fmt.Errorf("creating or updating configuration file: %w", err)
-			}
-
-			return nil
-		} else if err != nil {
-			return fmt.Errorf("parsing first line of file '%s': %w", varFile, err)
-		}
-
-		existingRef := fmt.Sprintf("%s-v%s", jsonSchemaMetdata.Template, jsonSchemaMetdata.Version)
-		if existingRef == pkg.Ref {
-			// No need to update the varFile with a new JSON schema, as the existing one is as declared in the pacckage
+		if existingSchema.Ref() == pkg.Ref {
+			// No need to update the varFile with a new JSON schema, as the existing one is as declared in the package
 			// manifest.
 			continue
 		}
@@ -178,14 +169,44 @@ func (u Updater) setJsonSchemaDeclarationInVarFiles(selectedPackages []common.Pa
 	return nil
 }
 
-func getLastVarFile(pkg common.Package, workingDirectory string) (string, bool) {
-	if len(pkg.VarFiles) > 0 {
-		varFileRelative := pkg.VarFiles[len(pkg.VarFiles)-1]
-		varFile := path.Join(workingDirectory, varFileRelative)
-		return varFile, true
+// findSchemaVarFile returns the var file that should receive the package's JSON schema declaration.
+//
+// The file is selected by looking at the schema declaration each var file already carries, instead of relying on the
+// position of the file in pkg.VarFiles (the position is meaningful to Boilerplate, but says nothing about which file
+// is the package's own config). The rules are:
+//
+//   - A var file whose declaration references the package's template is a candidate. If several var files qualify,
+//     the last one wins.
+//   - A var file that declares a different template (for example a shared common-config.yml declared by another
+//     package) is never selected, as overwriting its declaration would break schema validation for the other users
+//     of the file.
+//   - A var file without a (parseable) schema declaration is never selected. `ok pkg add` scaffolds the declaration
+//     into the package's var file, so guessing by position here would risk writing a package-specific declaration
+//     into a shared file.
+//
+// If no var file qualifies, found is false.
+func findSchemaVarFile(pkg common.Package, workingDirectory string) (varFile string, existingSchema metadata.JsonSchema, found bool) {
+	for _, varFileRelative := range pkg.VarFiles {
+		candidate := path.Join(workingDirectory, varFileRelative)
+
+		jsonSchema, err := metadata.ParseFirstLine(candidate)
+		if err != nil {
+			// The file is missing, empty, or has no parseable schema declaration on its first line, so we cannot
+			// tell if it belongs to this package.
+			continue
+		}
+
+		if jsonSchema.Template != pkg.Template {
+			// The file declares a schema for a different template, e.g. a shared config file.
+			continue
+		}
+
+		varFile = candidate
+		existingSchema = jsonSchema
+		found = true
 	}
 
-	return "", false
+	return varFile, existingSchema, found
 }
 
 type Options struct {

--- a/pkg/pkg/update/update_test.go
+++ b/pkg/pkg/update/update_test.go
@@ -1,6 +1,10 @@
 package update
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/oslokommune/ok/pkg/pkg/common"
@@ -110,44 +114,247 @@ func TestUpdatedPackages(t *testing.T) {
 	}
 }
 
-func TestGetLastConfigFile(t *testing.T) {
+// schemaLine returns a JSON schema declaration line as scaffolded by `ok pkg add`,
+// for a package ref such as "load-balancing-alb-v5.1.0".
+func schemaLine(ref string) string {
+	return fmt.Sprintf(
+		"# yaml-language-server: $schema=https://raw.githubusercontent.com/oslokommune/golden-path-boilerplate-schemas/refs/heads/main/schemas/%s.schema.json",
+		ref)
+}
+
+// captureStderr runs fn and returns everything fn wrote to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+func TestSetJsonSchemaDeclarationInVarFiles(t *testing.T) {
+	// File contents modeled on a real stack layout:
+	//   dev/common-config.yml                          (shared across stacks, no schema declaration)
+	//   dev/load-balancing-alb-nhn/package-config.yml  (scaffolded schema declaration)
+	// with workingDirectory = dev/load-balancing-alb-nhn.
+	commonConfig := "AccountId: \"123456789012\"\nRegion: \"eu-north-1\"\nTeam: \"legevaktmottak\"\n"
+	packageConfigOld := schemaLine("load-balancing-alb-v5.1.0") + "\nStackName: \"load-balancing-alb-nhn\"\n"
+	packageConfigNew := schemaLine("load-balancing-alb-v5.2.0") + "\nStackName: \"load-balancing-alb-nhn\"\n"
+
 	tests := []struct {
-		name     string
-		pkg      common.Package
-		expected string
-		ok       bool
+		name string
+		// files maps a path relative to the repo root to its content. workingDirectory is dev/load-balancing-alb-nhn.
+		files           map[string]string
+		packages        []common.Package
+		expectedFiles   map[string]string
+		expectedWarning string
 	}{
 		{
-			name: "package with var files",
-			pkg: common.Package{
-				VarFiles: []string{"config1.yaml", "config2.yaml"},
+			name: "conventional order writes declaration into the declared package config",
+			files: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigOld,
 			},
-			expected: "config2.yaml",
-			ok:       true,
+			packages: []common.Package{
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"../common-config.yml", "package-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigNew,
+			},
 		},
 		{
-			name: "package with one var files",
-			pkg: common.Package{
-				VarFiles: []string{"config1.yaml"},
+			name: "reversed order does not write into the shared common config listed last",
+			files: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigOld,
 			},
-			expected: "config1.yaml",
-			ok:       true,
+			packages: []common.Package{
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"package-config.yml", "../common-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigNew,
+			},
 		},
 		{
-			name: "package without var files",
-			pkg: common.Package{
-				VarFiles: []string{},
+			name: "multiple var files declaring the same template: last match wins",
+			files: map[string]string{
+				"dev/load-balancing-alb-nhn/base-config.yml":    schemaLine("load-balancing-alb-v5.0.0") + "\nBase: true\n",
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigOld,
 			},
-			expected: "",
-			ok:       false,
+			packages: []common.Package{
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"base-config.yml", "package-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/load-balancing-alb-nhn/base-config.yml":    schemaLine("load-balancing-alb-v5.0.0") + "\nBase: true\n",
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigNew,
+			},
+		},
+		{
+			name: "var file declaring a different template is never written to",
+			files: map[string]string{
+				"dev/common-config.yml":                         schemaLine("app-v1.0.0") + "\n" + commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": "StackName: \"load-balancing-alb-nhn\"\n",
+			},
+			packages: []common.Package{
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"package-config.yml", "../common-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/common-config.yml":                         schemaLine("app-v1.0.0") + "\n" + commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": "StackName: \"load-balancing-alb-nhn\"\n",
+			},
+			expectedWarning: "no var file of package '.' declares a JSON schema for template 'load-balancing-alb'",
+		},
+		{
+			name: "no var file with a declaration: warn and skip instead of guessing by position",
+			files: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": "StackName: \"load-balancing-alb-nhn\"\n",
+			},
+			packages: []common.Package{
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"package-config.yml", "../common-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": "StackName: \"load-balancing-alb-nhn\"\n",
+			},
+			expectedWarning: "no var file of package '.' declares a JSON schema for template 'load-balancing-alb'",
+		},
+		{
+			name: "skipping one package does not abort the remaining packages",
+			files: map[string]string{
+				"dev/load-balancing-alb-nhn/app-config.yml":     "AppName: \"hello\"\n",
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigOld,
+			},
+			packages: []common.Package{
+				{
+					Template:     "app",
+					Ref:          "app-v9.0.0",
+					OutputFolder: "app-hello",
+					VarFiles:     []string{"app-config.yml"},
+				},
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"package-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/load-balancing-alb-nhn/app-config.yml":     "AppName: \"hello\"\n",
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigNew,
+			},
+			expectedWarning: "no var file of package 'app-hello' declares a JSON schema for template 'app'",
+		},
+		{
+			name: "declaration already up to date is left unchanged",
+			files: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigNew,
+			},
+			packages: []common.Package{
+				{
+					Template:     "load-balancing-alb",
+					Ref:          "load-balancing-alb-v5.2.0",
+					OutputFolder: ".",
+					VarFiles:     []string{"../common-config.yml", "package-config.yml"},
+				},
+			},
+			expectedFiles: map[string]string{
+				"dev/common-config.yml":                         commonConfig,
+				"dev/load-balancing-alb-nhn/package-config.yml": packageConfigNew,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, ok := getLastVarFile(tt.pkg, "")
-			require.Equal(t, tt.ok, ok)
-			require.Equal(t, tt.expected, result)
+			rootDir := t.TempDir()
+			for relPath, content := range tt.files {
+				fullPath := filepath.Join(rootDir, relPath)
+				require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+				require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644))
+			}
+			workingDirectory := filepath.Join(rootDir, "dev", "load-balancing-alb-nhn")
+
+			var err error
+			stderr := captureStderr(t, func() {
+				err = Updater{}.setJsonSchemaDeclarationInVarFiles(tt.packages, workingDirectory)
+			})
+			require.NoError(t, err)
+
+			if tt.expectedWarning == "" {
+				require.NotContains(t, stderr, "Warning")
+			} else {
+				require.Contains(t, stderr, tt.expectedWarning)
+			}
+
+			for relPath, expectedContent := range tt.expectedFiles {
+				content, err := os.ReadFile(filepath.Join(rootDir, relPath))
+				require.NoError(t, err)
+				require.Equal(t, expectedContent, string(content), "unexpected content in %s", relPath)
+			}
 		})
 	}
+}
+
+func TestFindSchemaVarFile(t *testing.T) {
+	t.Run("package without var files", func(t *testing.T) {
+		_, _, found := findSchemaVarFile(common.Package{Template: "app", VarFiles: []string{}}, t.TempDir())
+		require.False(t, found)
+	})
+
+	t.Run("missing var file is skipped without error", func(t *testing.T) {
+		pkg := common.Package{Template: "app", VarFiles: []string{"does-not-exist.yml"}}
+		_, _, found := findSchemaVarFile(pkg, t.TempDir())
+		require.False(t, found)
+	})
+
+	t.Run("matching declaration is found and parsed", func(t *testing.T) {
+		workingDirectory := t.TempDir()
+		varFile := filepath.Join(workingDirectory, "package-config.yml")
+		require.NoError(t, os.WriteFile(varFile, []byte(schemaLine("app-v1.2.3")+"\nAppName: \"hello\"\n"), 0o644))
+
+		pkg := common.Package{Template: "app", VarFiles: []string{"package-config.yml"}}
+		selected, existingSchema, found := findSchemaVarFile(pkg, workingDirectory)
+		require.True(t, found)
+		require.Equal(t, varFile, selected)
+		require.Equal(t, "app-v1.2.3", existingSchema.Ref())
+	})
 }


### PR DESCRIPTION
## Problem

The line at the top of a package config file (`# yaml-language-server: $schema=...`) is what gives teams IDE autocomplete and validation. When `ok pkg update` refreshes that line, it picked which file to write into **by position in the list** — effectively "always the last var file". That only works under an unwritten convention about file ordering. Order the list differently and the tool stamps one package's schema into `common-config.yml`, a file **shared by every stack in the repo**, silently breaking IDE validation everywhere it is used. A second hidden bug made the tool quietly stop updating all remaining packages the moment one file lacked a declaration. This PR stops the guessing: the declaration goes to the file that already says it belongs to that template, files belonging to something else are never touched, and when nothing matches the tool warns instead of gambling.

`ok pkg update --update-schema` wrote the `# yaml-language-server: $schema=...` declaration into the var file chosen by **position**: `getLastVarFile` blindly returned `pkg.VarFiles[len(pkg.VarFiles)-1]`. This silently required the convention `[common-config.yml first, package config last]`. With any other ordering, `ok` wrote a package-specific schema declaration into the **shared** `common-config.yml`, breaking IDE schema validation for every stack that includes it.

There was also a latent bug in `setJsonSchemaDeclarationInVarFiles`: the missing-declaration branch ended with `return nil`, aborting the loop and silently skipping the schema update of all remaining packages. (The existing `bump-ref-field` integration test unknowingly depended on this: `load-balancing-alb-main`'s var file was never schema-updated, and the test never asserted it.)

## Why not a usage-count heuristic

An earlier proposal selected the var file by usage count across packages within one manifest (a file shared by several packages cannot be the package config). Validation against Oslo kommune team repos rejected this: **112 of 113 `packages.yml` manifests are single-package**. Sharing happens *across* manifests via `../common-config.yml`, not within one — so every var file is trivially "unique" and the heuristic degenerates to exactly the last-element bug it was meant to fix.

## Solution: select by declaration

Deployed package config files already carry a scaffold-time schema declaration matching their template (written by `ok pkg add`), while `common-config.yml` files carry none (verified in legevaktmottak-iac, utviklerflyt-iac and pirates-iac). The declaration itself identifies the right file, independent of ordering:

- Each var file's first line is parsed with the existing `metadata.ParseFirstLine`.
- The var file whose declared template equals `pkg.Template` receives the updated declaration. If several match, the last match wins.
- A var file declaring a **different** template (e.g. a shared config declared by another package type) is never written to.
- If **no** var file carries a matching declaration, the package is skipped with a warning instead of falling back to the last element. `ok pkg add` scaffolds declarations, so an all-undeclared package is a hand-rolled layout where positional guessing could recreate the original bug. The warning tells the user to add a `# yaml-language-server: $schema=...` declaration to the package's own var file.
- The early `return nil` is gone: skipped packages `continue`, so the remaining packages are still processed.

`VarFiles` ordering remains untouched for Boilerplate itself, where order is semantically meaningful (later files override earlier ones) — only the schema-target selection stops depending on it.

## Tests

`pkg/pkg/update/update_test.go`, with fixtures modeled on the real team-repo layout (`dev/common-config.yml` shared + `dev/<stack>/package-config.yml` declared):

- conventional order (`../common-config.yml`, `package-config.yml`) → declaration written to the declared package config
- **reversed order** (shared file listed last — the bug case) → shared file untouched
- multiple var files declaring the same template → last match wins
- var file declaring a different template → refused, warn + skip
- no declaration in any var file → warn + skip, nothing written
- a skipped package does not abort the remaining packages (early-return fix)
- already up-to-date declaration → left unchanged

`cmd/pkg/testdata/update/bump-ref-field` updated to the corrected behavior: `app-hello.yml` (undeclared) is no longer written to, and `config/load-balancing-alb-main.yml` — previously silently skipped due to the early return — is now asserted to receive its updated declaration.

`go build ./...`, `go vet ./...` and `go test ./...` pass.

Closes #314
Closes oslokommune/brolagtsti#41

