### PR TITLE
ci: harden auto-merge release PR workflow

### DIFF
--- a/.github/workflows/auto_merge_release_prs.yml
+++ b/.github/workflows/auto_merge_release_prs.yml
@@ -1,7 +1,7 @@
 name: Approve and merge release PRs
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -10,7 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    if: github.actor == 'okctl-bot'
+    if: >
+      github.actor == 'okctl-bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--')
 
     name: Approve and merge release PRs
 

--- a/.github/workflows/auto_merge_release_prs.yml
+++ b/.github/workflows/auto_merge_release_prs.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Approve the PR with okctl-bot
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           BODY_TEXT=$(cat <<- EOM
             _Beep boop_ :robot:
@@ -34,7 +35,7 @@ jobs:
             [I was summoned by workflow run `${{ github.run_id }}` (click to see run)](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
           EOM
           )
-          gh pr review --approve "${{github.event.pull_request.html_url}}" --body "$BODY_TEXT"
+          gh pr review --approve "$PR_URL" --body "$BODY_TEXT"
 
 
       # This has to be done because release-please does not support signing commits
@@ -42,4 +43,5 @@ jobs:
       - name: Squash and merge the PR
         env:
           GH_TOKEN: ${{ secrets.OKCTL_FINE_GRAINED_TOKEN }}
-        run: gh pr merge --squash --admin "${{github.event.pull_request.html_url}}"
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --squash --admin "$PR_URL"


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/auto_merge_release_prs.yml` based on [zizmor](https://docs.zizmor.sh) findings:

- **Replace `pull_request_target` with `pull_request`** — the workflow never checks out or runs PR code, and release-please PRs always come from `release-please--branches--main` in this repository, so the fork-capable (and [fundamentally risky](https://docs.zizmor.sh/audits/#dangerous-triggers)) trigger granted more privilege than needed.
- **Tighten the job guard** — in addition to `github.actor == 'okctl-bot'`, require the PR head to be a `release-please--` branch in this repository. Previously, any PR the bot account touched would be auto-approved and admin-merged; now only release PRs qualify.
- **Pass the PR URL to `gh` via an env var** instead of expanding `${{ github.event.pull_request.html_url }}` inline in `run` blocks, removing the template-injection point.

`zizmor` now reports no findings for this workflow (previously 1 dangerous-triggers + 2 template-injection errors).

## Test plan

- [x] `zizmor .github/workflows/auto_merge_release_prs.yml` → no findings
- [ ] Verify the next release-please PR is still auto-approved and merged