### PR TITLE
ci(deps): enable 7-day Dependabot package cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/" # This should be / rather than .github/workflows
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       github-actions-all:
         patterns:
@@ -17,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     groups:
       gomod-all:
         patterns:
@@ -28,6 +32,8 @@ updates:
     directory: "docs-optimizer"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       npm-all:
         patterns:


### PR DESCRIPTION
## Summary

Enables the [Dependabot package cooldown](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/) feature explicitly with a 7-day window across all ecosystems (`github-actions`, `gomod`, `npm`).

Dependabot now waits until a new release has been available on its registry for at least 7 days before opening a version-update PR, **up from GitHub's new 3-day default**. This reduces exposure to compromised or broken releases by giving the community time to detect and report issues first.

## Notes

- Security updates bypass the cooldown and open immediately.