### PR TITLE
docs: fix prose defects in the generated CLI reference

### DIFF
--- a/cmd/data/init.go
+++ b/cmd/data/init.go
@@ -6,10 +6,10 @@ import (
 )
 
 var (
-	flagBranch     string
-	flagConfigFile string
-	flagOutputDir  string
-	flagTag        string
+	flagBranch      string
+	flagConfigFile  string
+	flagOutputDir   string
+	flagTag         string
 	flagTemplateDir string
 )
 
@@ -22,7 +22,7 @@ var InitCommand = &cobra.Command{
 The TEMPLATE_PATH is optional. If not provided, uses the Oslo kommune custom template.
 You can override the default template URL with the DATA_TEMPLATE_URL environment variable.
 
-This command is a wrapper around 'databricks bundle init' that uses Oslo kommune's
+This command is a wrapper around ` + "`databricks bundle init`" + ` that uses Oslo kommune's
 standard Databricks project template by default, while still allowing you to use
 any other template (built-in or custom) by specifying it explicitly.`,
 	Example: `  # Use Oslo kommune template (default)

--- a/docs-optimizer/index.js
+++ b/docs-optimizer/index.js
@@ -82,6 +82,34 @@ const processMarkdownNode = (node) => {
   }
 };
 
+// Shell names are product names when used as words in a sentence. Cobra
+// generates them lowercase, which reads as a misspelling in prose. The literal
+// argument the user types (`ok completion powershell`) stays lowercase, and is
+// left alone because codeFontCommandNamesPlugin has already put it in code font.
+const shellNames = {
+  bash: "Bash",
+  zsh: "Zsh",
+  fish: "Fish",
+  powershell: "PowerShell",
+};
+
+// Match a shell name as a standalone word only. The lookarounds skip file paths
+// and compound identifiers such as `.zshrc`, `fish/completions` and
+// `bash-completion`, while still allowing trailing punctuation.
+const shellNamePattern = new RegExp(
+  String.raw`(?<![\w./-])(${Object.keys(shellNames).join("|")})(?![\w/-])`,
+  "g"
+);
+
+const capitalizeShellNamesPlugin = () => (tree) => {
+  visit(tree, "text", (node) => {
+    node.value = node.value.replace(
+      shellNamePattern,
+      (shellName) => shellNames[shellName]
+    );
+  });
+};
+
 // Literals that cobra emits as bare or single-quoted words mid-sentence. Outside
 // code font they read as misspellings, so each match becomes an inlineCode node.
 const inlineLiteralPattern = new RegExp(
@@ -175,8 +203,11 @@ const markdownProcessor = unified()
   .use(removeHeadingAndSubsectionsPlugin, {
     targetHeading: "Options inherited from parent commands",
   })
+  // Order matters: the code font passes run first so the literals they wrap are
+  // no longer text nodes when shell names get capitalized.
   .use(codeFontCommandNamesPlugin)
   .use(codeFontLiteralsPlugin)
+  .use(capitalizeShellNamesPlugin)
   .use(remarkStringify);
 
 const processMarkdownFile = async (markdownFilePath) => {

--- a/docs-optimizer/index.js
+++ b/docs-optimizer/index.js
@@ -82,6 +82,83 @@ const processMarkdownNode = (node) => {
   }
 };
 
+// Literals that cobra emits as bare or single-quoted words mid-sentence. Outside
+// code font they read as misspellings, so each match becomes an inlineCode node.
+const inlineLiteralPattern = new RegExp(
+  [
+    // Package names that cobra's help text wraps in single quotes.
+    String.raw`'(?<quoted>bash-completion)'`,
+    // The CLI's own name used as a word in a sentence. The lookarounds keep it
+    // from matching inside a longer word, a filename or a possessive.
+    String.raw`(?<![\w'./-])(?<command>ok)(?![\w'./-])`,
+  ].join("|"),
+  "g"
+);
+
+const splitTextNodeOnLiterals = (node, parentNode, nodeIndex) => {
+  const literalPattern = new RegExp(inlineLiteralPattern);
+  if (!literalPattern.test(node.value)) return;
+
+  literalPattern.lastIndex = 0;
+  const replacementNodes = [];
+  let lastMatchEnd = 0;
+
+  for (const match of node.value.matchAll(literalPattern)) {
+    if (match.index > lastMatchEnd) {
+      replacementNodes.push({
+        type: "text",
+        value: node.value.slice(lastMatchEnd, match.index),
+      });
+    }
+    const { quoted, command } = match.groups;
+    replacementNodes.push({ type: "inlineCode", value: quoted ?? command });
+    lastMatchEnd = match.index + match[0].length;
+  }
+
+  if (lastMatchEnd < node.value.length) {
+    replacementNodes.push({
+      type: "text",
+      value: node.value.slice(lastMatchEnd),
+    });
+  }
+
+  parentNode.children.splice(nodeIndex, 1, ...replacementNodes);
+  return nodeIndex + replacementNodes.length;
+};
+
+const codeFontLiteralsPlugin = () => (tree) => {
+  visit(tree, "text", (node, nodeIndex, parentNode) => {
+    if (!parentNode) return;
+    const nextIndex = splitTextNodeOnLiterals(node, parentNode, nodeIndex);
+    if (nextIndex !== undefined) return nextIndex;
+  });
+};
+
+// A bare command name in a sentence reads as a misspelling, because that is what
+// `fmt` and `aws` are outside code font. Cobra emits the command path bare in
+// both the page title and the "See also" link labels.
+const isCommandPath = (value) => /^ok(\s|$)/.test(value);
+
+const wrapChildInCodeFont = (node) => {
+  const [firstChild] = node.children;
+  if (firstChild?.type !== "text" || !isCommandPath(firstChild.value)) return;
+  node.children = [{ type: "inlineCode", value: firstChild.value }];
+};
+
+const codeFontCommandNamesPlugin = () => (tree) => {
+  visit(tree, "heading", (node) => {
+    // Only the page title holds a command path; the rest are section headings.
+    if (node.depth !== 1) return;
+    wrapChildInCodeFont(node);
+  });
+
+  visit(tree, "link", (node) => {
+    // "See also" links point at sibling pages; leave external links alone.
+    if (!node.url.endsWith(".md")) return;
+    wrapChildInCodeFont(node);
+  });
+};
+
 const markdownProcessor = unified()
   .use(remarkParse)
   .use(() => (tree) => {
@@ -98,6 +175,8 @@ const markdownProcessor = unified()
   .use(removeHeadingAndSubsectionsPlugin, {
     targetHeading: "Options inherited from parent commands",
   })
+  .use(codeFontCommandNamesPlugin)
+  .use(codeFontLiteralsPlugin)
   .use(remarkStringify);
 
 const processMarkdownFile = async (markdownFilePath) => {


### PR DESCRIPTION
## Description

The CLI reference under `docs/` is generated from cobra's help text and copied verbatim into [`oslokommune/golden-path-docs`](https://github.com/oslokommune/golden-path-docs), where it is linted with Vale against the GitLab style guide. Four terms in that output are prose defects that a downstream spelling allowlist is currently papering over. This fixes them at the source.

Vale's own `gitlab_base.Spelling` rule is explicit that an allowlist is the wrong remedy here:

> Commands, like `git clone` must use backticks, and must not be added to the exceptions.

## Motivation

Two rules, applied across all 19 generated pages:

1. **Shell names are product names in prose.** "Generate the autocompletion script for powershell" now reads PowerShell; likewise Bash, Zsh and Fish where they appear as words in a sentence. Where the same string is the literal argument the user types — `ok completion powershell` — it stays lowercase and is in code font.
2. **Command names in prose belong in code font.** `ok pkg fmt`, `ok aws`. Bare `fmt` and `aws` in a sentence read as misspellings, because that is what they are outside code font.

Commands, flags and examples are unchanged — only how they are typeset and how shell names are spelled.

## Which layer

The completion pages' wording, the page titles and the "See also" link labels are all emitted by cobra itself (`initDefaultCompletionCmd` and `doc.GenMarkdownTree`), not by any `Short`/`Long` in this repo, so those are fixed in the `docs-optimizer` post-processing step as three new remark passes:

- `codeFontCommandNamesPlugin` — wraps the command path in the H1 and in `*.md` link labels. External links untouched.
- `codeFontLiteralsPlugin` — bare `ok` mid-sentence and cobra's single-quoted `'bash-completion'` become inline code. Lookarounds keep it out of filenames and possessives.
- `capitalizeShellNamesPlugin` — shell names as sentence words only. Lookarounds skip `.zshrc`, `fish/completions` and `bash-completion`.

Pass ordering matters and is commented: the code font passes run first, so literal arguments are already `inlineCode` and stay lowercase when the capitalization pass runs. Code blocks are never text nodes, so examples and flag help are untouched.

Exactly one defect was in our own string, fixed at the source: `'databricks bundle init'` in `ok data init`'s `Long`. Since `Long` is a raw string literal, the backticks required concatenation.

## Verification

Ran Vale over all 19 generated pages using GitLab's real styles, pulled from `gitlab-org/gitlab@master:doc/.vale`:

| rule | before | after |
| --- | --- | --- |
| `gitlab_base.Spelling` | 24 | 5 |
| `gitlab_base.CodeblockFences` | 49 | 49 |
| `gitlab_base.FutureTense` | 4 | 4 |
| `gitlab_base.Simplicity` | 1 | 1 |
| `gitlab_base.LatinTerms` | 1 | 1 |

The eliminated spelling hits are precisely the four terms: `aws` (11), `powershell` (5), `fmt` (2), `databricks` (1). The remaining 5 are `kommune`, a genuine Norwegian proper noun that does belong in the allowlist. No other rule count moved, so nothing regressed.

`go build ./...` and `go test ./cmd/...` pass.

## Follow-up for golden-path-docs

Once this lands and the reference is regenerated, `aws`, `powershell`, `fmt` and `databricks` can be dropped from the downstream Vale spelling allowlist. `kommune` should stay.

## Note

The gofmt hook also realigned an unrelated `var` block in `cmd/data/init.go`. `cmd/aws/admin-session.go` is likewise not gofmt-clean on `main`, if someone wants to sweep that separately.