### PR TITLE
build(deps): set npm min-release-age to 7 days

### DIFF
--- a/docs-optimizer/.npmrc
+++ b/docs-optimizer/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary

Adds `docs-optimizer/.npmrc` with `min-release-age=7`.

`.github/dependabot.yml` already sets `cooldown.default-days: 7` for all three ecosystems (`github-actions`, `gomod`, `npm`), but that only governs the PRs Dependabot opens. This adds npm's own resolver-level gate, so a manual `npm install <pkg>` won't pull a version published in the last 7 days either.

Prompted by a pass over [cooldowns.dev](https://cooldowns.dev/) — npm was the only gap. Go has no native cooldown support, and no other listed package manager (uv/pip/poetry/pnpm/yarn/bun/deno/cargo/bundler/hex/mise) is used in this repo.

## Notes

- `min-release-age` requires **npm 11.6.2+**. It is a no-op on older npm, so this is forward-compatible rather than immediately enforcing.
- No npm runs in CI (`magefiles/magefile.go:33` invokes `node` directly), so this only affects local installs.

## Test plan

- [x] `npm config get min-release-age` in `docs-optimizer/` returns `7`