### PR TITLE
build: add mise config for the development toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,35 @@ source <(ok completions zsh)
 
 ## Development
 
-The development toolchain is declared in [`mise.toml`](mise.toml), so [mise](https://mise.jdx.dev) can install
-everything you need: Go, `mage`, Node (for the docs optimizer), `uv` and `cog` (for rendering this README),
-and the `boilerplate`, `fzf` and `yq` binaries that `ok` shells out to at runtime.
+The development toolchain is declared in [`mise.toml`](mise.toml), so [mise](https://mise.jdx.dev) installs
+everything you need at the pinned versions: Go, `mage`, Node (for the docs optimizer), `uv` and `cog` (for
+rendering this README), and the `boilerplate`, `fzf` and `yq` binaries that `ok` shells out to at runtime.
+
+### Setting up a new machine
+
+Install mise and activate it in your shell (once per machine):
 
 ```sh
 brew install mise
-mise trust
-mise install
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc  # use bash and ~/.bashrc for bash
+exec $SHELL
 ```
 
-Add [the mise activation hook](https://mise.jdx.dev/getting-started.html) to your shell to get the tools on
-`PATH` automatically, or prefix commands with `mise exec --`.
+Then clone the repository and install the tools:
+
+```sh
+git clone https://github.com/oslokommune/ok.git
+cd ok
+mise trust     # mise only reads config files you have trusted
+mise install   # downloads every tool in mise.toml
+```
+
+That is all — no `brew install go`, no `go install mage`. With mise activated, the pinned tools are on your
+`PATH` whenever you are inside the repository, and the versions you had before are back when you leave it.
+If you would rather not activate mise in your shell, prefix commands with `mise exec --`, e.g.
+`mise exec -- go test ./...`.
+
+### Tasks
 
 The `mage` targets are also exposed as mise tasks:
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ brew untap oslokommune/ok
 
 <!-- Cog renders the output of `ok --help` below. Manual changes will be overwritten.
 
-To install `cog`, you can use `pipx` by running the following command:
+`cog` is part of the mise toolchain (see the Development section), or install it with `uv`:
 
 ```sh
-pipx install cogapp
+uv tool install cogapp
 ```
 
 Once `cog` is installed, you can use the following command to generate the updated README.md file:
@@ -152,8 +152,8 @@ source <(ok completions zsh)
 ## Development
 
 The development toolchain is declared in [`mise.toml`](mise.toml), so [mise](https://mise.jdx.dev) can install
-everything you need: Go, `mage`, Node (for the docs optimizer), `cog` (for rendering this README), and the
-`boilerplate`, `fzf` and `yq` binaries that `ok` shells out to at runtime.
+everything you need: Go, `mage`, Node (for the docs optimizer), `uv` and `cog` (for rendering this README),
+and the `boilerplate`, `fzf` and `yq` binaries that `ok` shells out to at runtime.
 
 ```sh
 brew install mise

--- a/README.md
+++ b/README.md
@@ -148,3 +148,29 @@ Zsh:
 ```sh
 source <(ok completions zsh)
 ```
+
+## Development
+
+The development toolchain is declared in [`mise.toml`](mise.toml), so [mise](https://mise.jdx.dev) can install
+everything you need: Go, `mage`, Node (for the docs optimizer), `cog` (for rendering this README), and the
+`boilerplate`, `fzf` and `yq` binaries that `ok` shells out to at runtime.
+
+```sh
+brew install mise
+mise trust
+mise install
+```
+
+Add [the mise activation hook](https://mise.jdx.dev/getting-started.html) to your shell to get the tools on
+`PATH` automatically, or prefix commands with `mise exec --`.
+
+The `mage` targets are also exposed as mise tasks:
+
+```sh
+mise run build   # build the ok binary
+mise run test    # run the unit tests
+mise run docs    # regenerate and optimize docs/
+mise run readme  # re-render the `ok --help` output in README.md
+```
+
+Run `mise tasks` to list them.

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,9 @@
 # cooldown and `min-release-age` in docs-optimizer/.npmrc.
 minimum_release_age = "7d"
 
+# Install Python tools with uv instead of pipx.
+pipx.uvx = true
+
 [tools]
 # Keep in sync with the `go` directive in go.mod.
 go = "1.25.3"
@@ -15,6 +18,7 @@ go = "1.25.3"
 
 # `mage docs` runs docs-optimizer/index.js and renders the README with cog.
 node = "24.19.0"
+"aqua:astral-sh/uv" = "0.12.0"
 "pipx:cogapp" = "3.6.0"
 
 [tasks.build]

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,29 @@
+[tools]
+# Keep in sync with the `go` directive in go.mod.
+go = "1.25.3"
+"aqua:magefile/mage" = "1.17.2"
+
+# Runtime dependencies of the `ok` binary, also installed by the Homebrew formula.
+"aqua:gruntwork-io/boilerplate" = "0.16.0"
+"aqua:junegunn/fzf" = "0.74.2"
+"aqua:mikefarah/yq" = "4.53.3"
+
+# `mage docs` runs docs-optimizer/index.js and renders the README with cog.
+node = "24.19.0"
+"pipx:cogapp" = "3.6.0"
+
+[tasks.build]
+description = "Build the project"
+run = "mage build"
+
+[tasks.test]
+description = "Run the unit tests"
+run = "mage test"
+
+[tasks.docs]
+description = "Generate and optimize the docs"
+run = "mage docs"
+
+[tasks.readme]
+description = "Re-render the `ok --help` output in README.md"
+run = "cog -r README.md"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,8 @@
+[settings]
+# Ignore releases published within the last 7 days, matching the Dependabot
+# cooldown and `min-release-age` in docs-optimizer/.npmrc.
+minimum_release_age = "7d"
+
 [tools]
 # Keep in sync with the `go` directive in go.mod.
 go = "1.25.3"


### PR DESCRIPTION
## What

Adds a `mise.toml` so contributors can get the full toolchain with `mise install`, and a `## Development` section in the README describing it.

Tools declared:

| Tool | Why |
| --- | --- |
| `go` | pinned to the `go` directive in `go.mod` (1.25.3) |
| `aqua:magefile/mage` | the build tool used by CI and the devcontainer |
| `node` | `mage docs` runs `docs-optimizer/index.js` |
| `pipx:cogapp` | `cog -r README.md` renders the `ok --help` output |
| `aqua:gruntwork-io/boilerplate`, `aqua:junegunn/fzf`, `aqua:mikefarah/yq` | binaries `ok` shells out to at runtime, matching `depends_on` in the Homebrew formula |

The `mage` targets are also exposed as mise tasks (`mise run build` / `test` / `docs` / `readme`) so `mise tasks` lists everything runnable in the repo.

## Notes

- Nothing existing changes: `mage`, the devcontainer and the CI workflows keep working as before. mise is opt-in for local development.
- Versions are pinned explicitly. Bumping `go` here needs to stay in sync with `go.mod`.

## Verification

- `mise install` resolves all seven tools on macOS arm64.
- `mise run test` passes.
- `mise run build` produces the binary.