### PR TITLE
ci: publish releases as drafts and run GoReleaser as okctl-bot

### DIFF
--- a/.github/workflows/auto_merge_release_prs.yml
+++ b/.github/workflows/auto_merge_release_prs.yml
@@ -1,4 +1,4 @@
-name: Approve and merge release PRs
+name: Merge release PRs
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  auto-approve:
+  auto-merge:
 
     runs-on: ubuntu-latest
 
@@ -15,31 +15,10 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release-please--')
 
-    name: Approve and merge release PRs
-
-    permissions:
-      pull-requests: write
+    name: Merge release PRs
 
     steps:
 
-      - name: Approve the PR with okctl-bot
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          BODY_TEXT=$(cat <<- EOM
-            _Beep boop_ :robot:
-
-            I've automatically approved this PR.
-
-            [I was summoned by workflow run `${{ github.run_id }}` (click to see run)](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-          EOM
-          )
-          gh pr review --approve "$PR_URL" --body "$BODY_TEXT"
-
-
-      # This has to be done because release-please does not support signing commits
-      # https://github.com/googleapis/release-please/issues/1314
       - name: Squash and merge the PR
         env:
           GH_TOKEN: ${{ secrets.OKCTL_FINE_GRAINED_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '**/*.sh'
-      - '**/*.rb'
+      # NOTE: Formula/ is written by GoReleaser during a release. It is left out
+      # so that commit does not start another run.
       # NOTE: We need to trigger a release when a PR from release-please has been merged
       - ".release-please-manifest.json"
   workflow_dispatch:
@@ -74,7 +75,17 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OKCTL_FINE_GRAINED_TOKEN }}
+
+
+      # NOTE: This has to be the last step that touches the release. Immutable
+      # releases freeze the assets at publish time, so everything must already
+      # be attached.
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.OKCTL_FINE_GRAINED_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release edit "$TAG" --draft=false
 
 
   ################################################################################

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,12 @@ version: 2
 changelog:
   disable: true
 
+# Since GoReleaser attaches artifacts to a release after release-please has
+# created it, we create it as a draft and instead let a later step publish it.
+# This allows us to have immutable releases.
+release:
+  draft: true
+
 before:
   hooks:
     - ./scripts/completions.sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "commit-search-depth": 100,
   "release-type": "go",
   "separate-pull-requests": false,
+  "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "component": "",


### PR DESCRIPTION
## Description

- Create the GitHub release as a draft; publish it after the artifacts attach.
- Run GoReleaser as `okctl-bot`.
- Remove the approval step from the release PR workflow.
- Ignore `Formula/` changes in the release trigger.

## Motivation

Immutable releases freeze a release's assets at publish time, but GoReleaser attaches artifacts after release-please publishes. New rulesets on this repository also changed what the release automation can do.

## Details

`force-tag-creation` is necessary because GitHub does not create the Git tag for a draft release. Without it GoReleaser has no tag to build from.

The workflow no longer approves the release PR. A review from the workflow does not satisfy the required review, so the step had no effect.

The release trigger no longer includes `.rb` files. GoReleaser writes the formula during a release, and that commit would otherwise start a second run.

This needs a repository settings change before the first release - see [Slack](https://oslokommune.slack.com/archives/C018EFCSC4W/p1786099033452319?thread_ts=1786098417.086249&cid=C018EFCSC4W) for details.

Refs #531