### PR TITLE
Close the remaining dependency cooldown gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,10 @@ updates:
       prefix: ci(deps)
 
   - package-ecosystem: gomod
-    directory: "/"
+    # `magefiles` is a separate Go module, so it needs its own entry here.
+    directories:
+      - "/"
+      - "/magefiles"
     schedule:
       interval: daily
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 
+# `cooldown.default-days` holds back versions published less than 7 days ago, so
+# researchers get a chance to catch a compromised release before it reaches us.
+# It matches `min-release-age` in docs-optimizer/.npmrc and `minimum_release_age`
+# in mise.toml — keep the three in sync.
+#
+# Bypass: Dependabot already exempts security updates, so CVE fixes arrive
+# immediately. To let a specific package through for another reason, add it to
+# `cooldown.exclude` in that ecosystem's block, then remove the entry once the
+# update has landed.
+
 updates:
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,11 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: latest
+          # `latest` downloads whatever GoReleaser released most recently, with
+          # no cooldown, so pin an exact version instead. Dependabot does not
+          # bump this input — update it by hand, choosing a release that is at
+          # least 7 days old to match the cooldown elsewhere in the repo.
+          version: v2.17.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -37,16 +37,11 @@ brew untap oslokommune/ok
 
 <!-- Cog renders the output of `ok --help` below. Manual changes will be overwritten.
 
-`cog` is part of the mise toolchain (see the Development section), or install it with `uv`:
+`cog` is part of the mise toolchain, pinned in `mise.toml` and installed by `mise install` (see the
+Development section). Re-render this file with:
 
 ```sh
-uv tool install cogapp
-```
-
-Once `cog` is installed, you can use the following command to generate the updated README.md file:
-
-```sh
-cog -r README.md
+mise run readme
 ``` -->
 
 <!-- [[[cog

--- a/docs-optimizer/.npmrc
+++ b/docs-optimizer/.npmrc
@@ -1,1 +1,9 @@
+# Ignore versions published within the last 7 days, matching the Dependabot
+# cooldown in .github/dependabot.yml and `minimum_release_age` in mise.toml.
+# Requires npm 11.10.0 or later; older npm silently ignores this setting.
+#
+# Bypass: run a single command with `npm install --min-release-age=0` for an
+# urgent security fix, and drop the flag again afterwards. (Per-package
+# `min-release-age-exclude[]` needs npm 11.19.0, newer than the Node.js version
+# pinned in mise.toml.)
 min-release-age=7

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,11 @@
 [settings]
 # Ignore releases published within the last 7 days, matching the Dependabot
-# cooldown and `min-release-age` in docs-optimizer/.npmrc.
+# cooldown and `min-release-age` in docs-optimizer/.npmrc. Requires mise
+# 2026.6.2 or later; older mise silently ignores this setting.
+#
+# Bypass: add the tool to `minimum_release_age_excludes`, then remove it again
+# once the update has landed. Pinning an exact version below installs that
+# version regardless of the cooldown.
 minimum_release_age = "7d"
 
 # Install Python tools with uv instead of pipx.

--- a/test/installation/Dockerfile.archlinux
+++ b/test/installation/Dockerfile.archlinux
@@ -1,3 +1,6 @@
+# No dependency cooldown here: neither Docker Hub tags nor `pacman` support one.
+# This image is a throwaway test fixture that installs our own release artifact,
+# so it never resolves third-party application dependencies.
 FROM archlinux:latest
 
 RUN pacman -Sy --noconfirm github-cli

--- a/test/installation/Dockerfile.fedora
+++ b/test/installation/Dockerfile.fedora
@@ -1,3 +1,6 @@
+# No dependency cooldown here: neither Docker Hub tags nor `dnf` support one.
+# This image is a throwaway test fixture that installs our own release artifact,
+# so it never resolves third-party application dependencies.
 FROM fedora:latest
 
 RUN dnf install -y dnf5-plugins git && \

--- a/test/installation/Dockerfile.ubuntu
+++ b/test/installation/Dockerfile.ubuntu
@@ -1,3 +1,6 @@
+# No dependency cooldown here: neither Docker Hub tags nor `apt` support one.
+# This image is a throwaway test fixture that installs our own release artifact,
+# so it never resolves third-party application dependencies.
 FROM ubuntu:latest
 
 RUN apt-get update && apt-get install -y wget gpg


### PR DESCRIPTION
The repo already had a 7-day cooldown on Dependabot, `docs-optimizer/.npmrc`, and `mise.toml`. This covers the sites that were still resolving without one, and documents the bypass at each setting.

Everything stays at **7 days** to match what was already here.

## Gaps closed

**`magefiles/go.mod` was invisible to Dependabot.** It is a separate Go module, and the `gomod` entry only watched `/`. It is still on `mage v1.15.0` while the root module is on `v1.17.2` — that gap is the evidence it was never being updated. Now `directories: ["/", "/magefiles"]`.

**GoReleaser resolved with no gate.** `release.yml` passed `version: latest` to `goreleaser-action`, so every release downloaded whatever GoReleaser had published most recently. Pinned to `v2.17.1`. Dependabot does *not* bump this input, so it needs a manual bump — the comment says so.

**The README offered `uv tool install cogapp`** as an alternative to mise. `cogapp` is already pinned in `mise.toml`, so that was a second, ungated way to resolve the same tool. Removed in favour of `mise install` / `mise run readme`, both of which the Development section already documents.

## Also

- **Bypass documented** beside each setting. A cooldown with no documented escape hatch gets deleted the first time it blocks a hotfix.
- **No-cooldown sites recorded.** The three test Dockerfiles (`FROM *:latest` plus `apt`/`dnf`/`pacman`) have no mechanism available; noted in each so the next audit does not re-derive it.

## Version gate

Both configured tools clear their minimum, so neither is silently ignoring its setting:

- npm **11.17.0** (via mise's Node 24.19.0) >= 11.10.0. Below 11.19.0 though, so per-package `min-release-age-exclude[]` is unavailable — the bypass is `--min-release-age=0` per command.
- mise **2026.8.2** >= 2026.6.2.

## Enforcement observed

Each gate held back a real version rather than just reading back correctly:

| Manager | Gate on | Gate off |
| --- | --- | --- |
| npm (`@aws-sdk/client-s3`) | `3.1099.0` | `3.1105.0` |
| mise / core (`node`) | `26.5.1` | `26.7.0` |
| mise / aqua (`fzf`) | `0.74.1` | `0.74.2` |

mise enforces on the `core` and `aqua` backends, which covers every tool in `mise.toml`. `pipx:cogapp` was inconclusive — 3.6.0 is both the latest and well outside the window — but it is pinned exactly, and a pinned version installs regardless of the cooldown either way.

## What this leaves open

Go modules have no native cooldown ([golang/go#76485](https://github.com/golang/go/issues/76485) is unaccepted), so `go get` on a developer machine bypasses everything — the exact versions in `go.mod`, `go.sum`, and the Dependabot gate are the whole defence there. Same for Homebrew and the distro packages.

A cooldown also does nothing against typosquatting, a long-term maintainer compromise, or a vulnerability in a version already installed. It pairs with `npm audit` and Dependabot security alerts — which are deliberately exempt from the cooldown, so CVE fixes still arrive immediately.