### PR TITLE
ci: bump setup-ok to v1.6.3 to satisfy SHA pinning policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       # We don't need the ok binary from the setup-ok action, but we need the dependencies.
       - name: Install ok dependencies
-        uses: oslokommune/composite-actions/setup-ok@ec8af16c03d62d35987ff358fda9509908ad79eb # setup-ok: v1.3.0
+        uses: oslokommune/composite-actions/setup-ok@6054e3b0e9d06f15d19d9b6885a0c0e1a58ae9c7 # setup-ok: v1.6.3
 
 
       - name: Run tests


### PR DESCRIPTION
## Summary

Fixes the workflow failure:

> Error: The action `actions/cache/restore@v4` is not allowed in `oslokommune/ok` because all actions must be pinned to a full-length commit SHA.

Every action referenced directly in this repo was already SHA-pinned. The offender was a *nested* action: `oslokommune/composite-actions/setup-ok` at `ec8af16` (v1.3.0) is a composite action whose own `action.yml` had `uses: actions/cache/restore@v4` unpinned. GitHub's pinning policy applies transitively.

Bumps the pin in `.github/workflows/test.yml` to `setup-ok: v1.6.3` (`6054e3b`), where both nested refs are pinned to `actions/cache/{restore,save}@caa2961 # v5.1.0`.

## Notes

- Input-compatible: all of v1.6.3's inputs have defaults, and this workflow passes none.
- No upstream issue needed — already fixed on `composite-actions` `main` and in the v1.6.3 tag.
- Audited all 13 direct action refs across the 7 workflows and resolved each `action.yml` at its pinned SHA. `setup-ok` was the only composite action; the other 12 are `using: node24` JavaScript actions, which cannot nest `uses:` at all. `release.yml` calls the local reusable workflow `test_os_packages.yml`, which is exempt from the policy and whose own actions are pinned.

## Test plan

- [ ] `Test` workflow runs green on this PR (exercises the bumped `setup-ok`)